### PR TITLE
Support file attachments for memories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.11"
 dependencies = [
     "python-frontmatter>=1.1.0",
     "google-genai>=1.0.0",
+    "google-cloud-storage>=2.0.0",
     "python-dotenv>=1.0.0",
     "markdown>=3.5",
 ]

--- a/src/memory.py
+++ b/src/memory.py
@@ -30,12 +30,14 @@ class Memory:
     title: str | None = None
     time: str | None = None
     place: str | None = None
+    attachments: list[str] | None = None
 
     @classmethod
     def load(cls, path: Path) -> Memory:
         """Load a memory from a markdown file with YAML frontmatter."""
         post = frontmatter.load(path)
         raw_target = post.metadata.get("target")
+        raw_attachments = post.metadata.get("attachments")
         return cls(
             target=_parse_date(raw_target) if raw_target is not None else None,
             expires=_parse_date(post.metadata["expires"]),
@@ -43,6 +45,7 @@ class Memory:
             title=post.metadata.get("title"),
             time=post.metadata.get("time"),
             place=post.metadata.get("place"),
+            attachments=list(raw_attachments) if raw_attachments else None,
         )
 
     def dump(self, path: Path) -> None:
@@ -57,6 +60,8 @@ class Memory:
             metadata["time"] = self.time
         if self.place is not None:
             metadata["place"] = self.place
+        if self.attachments:
+            metadata["attachments"] = self.attachments
         post = frontmatter.Post(self.content, **metadata)
         path.write_text(frontmatter.dumps(post) + "\n")
 

--- a/src/publisher.py
+++ b/src/publisher.py
@@ -27,6 +27,14 @@ def load_memories(directory: Path, today: date) -> list[Memory]:
     return memories
 
 
+def _attachment_label(url: str) -> str:
+    """Derive a human-readable label from an attachment URL."""
+    from urllib.parse import urlparse, unquote
+    path = unquote(urlparse(url).path)
+    name = path.rsplit("/", 1)[-1] if "/" in path else path
+    return name or "attachment"
+
+
 def _md_inline(text: str) -> str:
     """Render markdown but strip the wrapping <p> tag for inline use."""
     html = markdown.markdown(text)
@@ -49,6 +57,12 @@ def _render_event(mem: Memory) -> str:
     if mem.title and mem.content:
         content_html = markdown.markdown(mem.content)
         parts.append(f"<div>{content_html}</div>")
+    if mem.attachments:
+        links = " ".join(
+            f'<a href="{escape(url)}">{escape(_attachment_label(url))}</a>'
+            for url in mem.attachments
+        )
+        parts.append(f'<div class="attachments">Attachments: {links}</div>')
     parts.append("</li>")
     return "\n".join(parts)
 

--- a/src/storage.py
+++ b/src/storage.py
@@ -1,0 +1,28 @@
+"""Cloud storage helpers for uploading file attachments."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+
+def upload_to_gcs(local_path: Path, *, bucket: str | None = None) -> str:
+    """Upload a file to Google Cloud Storage and return its public URL.
+
+    The bucket name is read from the ``GCS_BUCKET`` environment variable
+    unless explicitly provided.  The file is stored under a unique key
+    based on a UUID to avoid collisions.
+    """
+    from google.cloud import storage  # lazy import
+
+    bucket_name = bucket or os.environ["GCS_BUCKET"]
+    client = storage.Client()
+    gcs_bucket = client.bucket(bucket_name)
+
+    ext = local_path.suffix
+    blob_name = f"attachments/{uuid.uuid4().hex}{ext}"
+    blob = gcs_bucket.blob(blob_name)
+    blob.upload_from_filename(str(local_path))
+    blob.make_public()
+    return blob.public_url

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -161,3 +161,28 @@ def test_generate_page_ongoing_in_this_week():
     conference_pos = html.index("Conference")
     assert this_week_pos < worship_pos < upcoming_pos
     assert upcoming_pos < conference_pos
+
+
+def test_generate_page_renders_attachments():
+    """Attachments are rendered as links."""
+    today = date(2026, 2, 18)
+    memories = [
+        Memory(target=date(2026, 2, 19), expires=date(2026, 3, 1),
+               content="See flyer", title="Event",
+               attachments=["https://storage.googleapis.com/bucket/flyer.pdf"]),
+    ]
+    html = generate_page(memories, today)
+    assert "Attachments:" in html
+    assert 'href="https://storage.googleapis.com/bucket/flyer.pdf"' in html
+    assert "flyer.pdf" in html
+
+
+def test_generate_page_no_attachments_no_section():
+    """No attachments div when memory has no attachments."""
+    today = date(2026, 2, 18)
+    memories = [
+        Memory(target=date(2026, 2, 19), expires=date(2026, 3, 1),
+               content="No files", title="Event"),
+    ]
+    html = generate_page(memories, today)
+    assert "Attachments:" not in html

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,46 @@
+"""Tests for the storage module."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def test_upload_to_gcs(tmp_path: Path):
+    mock_blob = MagicMock()
+    mock_blob.public_url = "https://storage.googleapis.com/test-bucket/attachments/abc123.pdf"
+
+    mock_bucket = MagicMock()
+    mock_bucket.blob.return_value = mock_blob
+
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    mock_storage_module = MagicMock()
+    mock_storage_module.Client.return_value = mock_client
+
+    # google.cloud must have .storage attribute pointing to our mock
+    mock_google_cloud = MagicMock()
+    mock_google_cloud.storage = mock_storage_module
+
+    mock_google = MagicMock()
+    mock_google.cloud = mock_google_cloud
+
+    test_file = tmp_path / "doc.pdf"
+    test_file.write_bytes(b"fake-pdf")
+
+    with patch.dict("os.environ", {"GCS_BUCKET": "test-bucket"}), \
+         patch.dict(sys.modules, {
+             "google": mock_google,
+             "google.cloud": mock_google_cloud,
+             "google.cloud.storage": mock_storage_module,
+         }), \
+         patch("storage.uuid") as mock_uuid:
+        mock_uuid.uuid4.return_value = MagicMock(hex="abc123")
+        from storage import upload_to_gcs
+        url = upload_to_gcs(test_file)
+
+    assert url == "https://storage.googleapis.com/test-bucket/attachments/abc123.pdf"
+    mock_client.bucket.assert_called_once_with("test-bucket")
+    mock_bucket.blob.assert_called_once_with("attachments/abc123.pdf")
+    mock_blob.upload_from_filename.assert_called_once_with(str(test_file))
+    mock_blob.make_public.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds an optional `attachments` field to the `Memory` dataclass (list of URLs stored in YAML frontmatter)
- New `src/storage.py` module uploads files to Google Cloud Storage via `--attach` flag on the committer CLI
- Publisher renders attachment URLs as download links in the generated HTML page
- AI prompt updated to handle attachment URLs and include them in the memory JSON response

Closes #3

## Test plan
- [x] `Memory` roundtrip tests with and without attachments
- [x] File format tests verifying attachments appear/don't appear in frontmatter
- [x] Committer `build_ai_request` tests with/without attachment URLs
- [x] Committer `main` end-to-end test with `--attach` flag (mocked GCS upload)
- [x] Publisher rendering tests for attachment links
- [x] Storage `upload_to_gcs` unit test with mocked GCS client
- [x] All 43 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)