### PR TITLE
Fix Google sign-in UX: redirect fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ service cloud.firestore {
 
 The API key is not a secret; access control is enforced by Firestore security rules.
 
+### Troubleshooting Google Sign-In
+
+If sign-in doesn't work (popup flashes and disappears, or nothing happens):
+
+1. **Authorized domains** — In Firebase Console → Authentication → Settings → Authorized domains, make sure `zhihan.github.io` is listed.
+2. **Google provider enabled** — In Firebase Console → Authentication → Sign-in method, confirm the Google provider is enabled.
+3. **Popup blockers** — Browser extensions or built-in popup blockers can prevent the sign-in popup from opening. If the popup is blocked, an error message will appear with a "Sign in (redirect)" button as a fallback.
+4. **Safari / third-party cookie restrictions** — Safari blocks third-party cookies by default, which can prevent popup-based sign-in. Use the "Sign in (redirect)" button instead, which navigates to Google's sign-in page and redirects back.
+5. **Incognito / private browsing** — Some browsers restrict storage in private windows. Try a normal browsing window.
+
 ### Named database support
 
 The Firebase Web SDK (v10.4+) supports non-default database IDs via `getFirestore(app, "database-id")`. The client page targets the `living-memories-db` database directly. If you encounter issues with named database access, you can either:

--- a/client/index.html
+++ b/client/index.html
@@ -19,15 +19,18 @@
   .authbar button { padding: 0.4rem 0.7rem; border-radius: 6px; border: 1px solid #ccc; background: white; cursor: pointer; }
   .authbar button:hover { background: #f2f2f2; }
   .authbar .who { color: #666; font-size: 0.95rem; }
+  .auth-error { color: #c00; background: #fff0f0; border: 1px solid #fcc; border-radius: 6px; padding: 0.5rem 0.75rem; margin: 0.5rem 0; font-size: 0.9rem; }
 </style>
 </head>
 <body>
 <h1>Our Church Events</h1>
 <div class="authbar">
   <button id="signin" type="button">Sign in with Google</button>
+  <button id="signin-redirect" type="button" style="display:none">Sign in (redirect)</button>
   <button id="signout" type="button" style="display:none">Sign out</button>
   <span id="who" class="who"></span>
 </div>
+<div id="auth-error"></div>
 <div id="app"><p class="loading">Please sign in to load events&hellip;</p></div>
 
 <script type="module">
@@ -46,7 +49,7 @@ const DEFAULT_USER_ID = "cambridge-lexington";
 
 // --- Firebase SDK (CDN, modular) ---
 import { initializeApp }   from "https://www.gstatic.com/firebasejs/11.4.0/firebase-app.js";
-import { getAuth, GoogleAuthProvider, signInWithPopup, signOut, onAuthStateChanged }
+import { getAuth, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signOut, onAuthStateChanged }
   from "https://www.gstatic.com/firebasejs/11.4.0/firebase-auth.js";
 import { getFirestore, collection, query, where, getDocs }
   from "https://www.gstatic.com/firebasejs/11.4.0/firebase-firestore.js";
@@ -58,16 +61,52 @@ const db  = getFirestore(app, DATABASE_ID);
 
 // --- Auth UI ---
 const signInBtn = document.getElementById("signin");
+const signInRedirectBtn = document.getElementById("signin-redirect");
 const signOutBtn = document.getElementById("signout");
 const whoEl = document.getElementById("who");
+const authErrorEl = document.getElementById("auth-error");
+
+const provider = new GoogleAuthProvider();
+
+function showAuthError(msg) {
+  authErrorEl.innerHTML = `<p class="auth-error">${escapeHtml(msg)}</p>`;
+}
+
+function clearAuthError() {
+  authErrorEl.innerHTML = "";
+}
 
 signInBtn.addEventListener("click", async () => {
-  const provider = new GoogleAuthProvider();
-  await signInWithPopup(auth, provider);
+  clearAuthError();
+  try {
+    await signInWithPopup(auth, provider);
+  } catch (err) {
+    console.error("Popup sign-in failed:", err);
+    showAuthError(`Popup sign-in failed: ${err.message}. Try the "Sign in (redirect)" button instead.`);
+    signInRedirectBtn.style.display = "";
+  }
+});
+
+signInRedirectBtn.addEventListener("click", async () => {
+  clearAuthError();
+  try {
+    await signInWithRedirect(auth, provider);
+  } catch (err) {
+    console.error("Redirect sign-in failed:", err);
+    showAuthError(`Redirect sign-in failed: ${err.message}`);
+  }
 });
 
 signOutBtn.addEventListener("click", async () => {
+  clearAuthError();
   await signOut(auth);
+});
+
+// Handle redirect result on page load
+getRedirectResult(auth).catch((err) => {
+  if (err.code === "auth/credential-already-in-use") return;
+  console.error("Redirect result error:", err);
+  showAuthError(`Sign-in error: ${err.message}`);
 });
 
 // --- Helpers ---
@@ -217,6 +256,7 @@ async function loadAndRender() {
 
 function setSignedOutUi() {
   signInBtn.style.display = "";
+  signInRedirectBtn.style.display = "none";
   signOutBtn.style.display = "none";
   whoEl.textContent = "";
   document.getElementById("app").innerHTML = `<p class="loading">Please sign in to load events…</p>`;
@@ -224,8 +264,10 @@ function setSignedOutUi() {
 
 function setSignedInUi(user) {
   signInBtn.style.display = "none";
+  signInRedirectBtn.style.display = "none";
   signOutBtn.style.display = "";
   whoEl.textContent = user.email || user.displayName || "Signed in";
+  clearAuthError();
 }
 
 onAuthStateChanged(auth, async (user) => {


### PR DESCRIPTION
## Summary
- Wrap `signInWithPopup` in try/catch and display errors visibly on the page (not just console)
- Add "Sign in (redirect)" fallback button that appears when popup sign-in fails
- Handle `getRedirectResult` on page load to complete redirect-based sign-in
- Add troubleshooting section to README (authorized domains, popup blockers, Safari settings)

## Test plan
- [ ] Test popup sign-in on Chrome (should work as before)
- [ ] Test with popup blocker enabled — error message appears, redirect button shown
- [ ] Test "Sign in (redirect)" button — redirects to Google, returns signed in
- [ ] Test on Safari — redirect flow works around third-party cookie restrictions
- [ ] Verify signing out resets UI (hides redirect button, clears errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)