### PR TITLE
Remove Python publisher from Pages deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,7 @@ name: Publish Site
 on:
   push:
     branches: [main]
-    # Re-deploy when memories change (server-side path) OR when the client homepage changes.
     paths:
-      - 'memories/**'
       - 'client/**'
       - '.github/workflows/publish.yml'
 
@@ -26,18 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install dependencies
-        run: pip install -e .
-
-      - name: Generate site (server-side)
-        run: python -m publisher --memories-dir memories/ --output-dir site/
-
-      - name: Replace homepage with client-side Firestore app
-        run: cp client/index.html site/index.html
+      - name: Prepare site directory
+        run: |
+          mkdir -p site
+          cp client/index.html site/index.html
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Living Memory
 
-A static website generator with no database. The "database" is an organized collection of markdown files stored in a git repo.
+A family events page backed by Firestore. The **GitHub Pages homepage** is a client-rendered page (`client/index.html`) that reads memories directly from Firestore in the browser — no server-side build required.
 
 ## How It Works
 
-1. **Committer** — CLI tool that adds event memories to the repo and pushes to GitHub.
-2. **Publisher** — GitHub Actions workflow that generates a static HTML page and deploys to GitHub Pages.
+1. **Committer** — CLI tool that adds event memories (to Firestore or local markdown files) and pushes to GitHub.
+2. **GitHub Pages** — On push to `client/**`, the workflow copies `client/index.html` to Pages. The page reads Firestore at runtime.
+3. **Publisher** (optional) — Can generate a static HTML snapshot locally for offline use or debugging, but is **not** part of the Pages deploy pipeline.
 
 ```
-User → committer → git push → GitHub Actions → publisher → static site
+User → committer → Firestore ← client/index.html (GitHub Pages)
 ```
 
 ## Quick Start
@@ -34,7 +35,9 @@ Options:
 
 The AI extracts event details from your message and decides whether to create a new memory or update an existing one.
 
-### Generate the site locally
+### Generate a static snapshot locally (optional)
+
+The publisher is not used in the Pages deploy but can still generate a local HTML snapshot:
 
 ```bash
 python -m publisher --memories-dir memories/ --output-dir site/


### PR DESCRIPTION
## Summary
- Remove setup-python, pip install, and publisher steps from the Pages workflow
- Workflow now just copies `client/index.html` → `site/index.html` and deploys
- Triggers on `client/**` and workflow file changes only (no more `memories/**` trigger)
- Update README to clarify the homepage is client-rendered from Firestore; publisher is optional for local snapshots

## Test plan
- [ ] Verify Pages workflow runs successfully after merge
- [ ] Confirm deployed site loads and reads from Firestore

🤖 Generated with [Claude Code](https://claude.com/claude-code)