### PR TITLE
Fix 'This Week' to reset on Sunday

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -132,15 +132,19 @@ function today() {
   return new Date(now.getFullYear(), now.getMonth(), now.getDate());
 }
 
+function weekStart(todayDate) {
+  // Sunday-to-Saturday week: week starts on the most recent Sunday.
+  const jsDay = todayDate.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+  const start = new Date(todayDate);
+  start.setDate(start.getDate() - jsDay);
+  return start;
+}
+
 function weekEnd(todayDate) {
-  // Match publisher: week ends on Sunday (weekday 0 in JS = Sunday = 6 in Python ISO)
-  // Python: week_end = today + timedelta(days=(6 - today.weekday()))  where Monday=0
-  // JS: getDay() Sunday=0 Mon=1 ... Sat=6
-  const jsDay = todayDate.getDay(); // 0=Sun
-  const pyDay = jsDay === 0 ? 6 : jsDay - 1; // convert to Mon=0 .. Sun=6
-  const daysUntilSunday = 6 - pyDay;
-  const end = new Date(todayDate);
-  end.setDate(end.getDate() + daysUntilSunday);
+  // Sunday-to-Saturday week: week ends on Saturday.
+  const start = weekStart(todayDate);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 6);
   return end;
 }
 
@@ -220,6 +224,7 @@ async function loadAndRender() {
   const appEl = document.getElementById("app");
   const userId = getUserId();
   const t = today();
+  const wStart = weekStart(t);
   const wEnd = weekEnd(t);
 
   appEl.innerHTML = `<p class="loading">Loading events from Firestore…</p>`;
@@ -247,8 +252,8 @@ async function loadAndRender() {
     return a.target < b.target ? -1 : a.target > b.target ? 1 : 0;
   });
 
-  // Split into sections (matches publisher logic)
-  const thisWeek = memories.filter(m => m.target == null || parseDate(m.target) <= wEnd);
+  // Split into sections (matches publisher logic — Sunday-to-Saturday weeks)
+  const thisWeek = memories.filter(m => m.target == null || (parseDate(m.target) >= wStart && parseDate(m.target) <= wEnd));
   const upcoming = memories.filter(m => m.target != null && parseDate(m.target) > wEnd);
 
   appEl.innerHTML = renderSection("This Week", thisWeek)

--- a/src/publisher.py
+++ b/src/publisher.py
@@ -106,6 +106,19 @@ def _render_event(mem: Memory) -> str:
     return f"<li><strong>{title_html}</strong></li>"
 
 
+def week_bounds(today: date) -> tuple[date, date]:
+    """Return (week_start, week_end) for a Sunday-to-Saturday week.
+
+    *week_start* is the most recent Sunday (<= today) and *week_end* is the
+    following Saturday.  On Sunday itself, week_start == today.
+    """
+    # date.isoweekday(): Mon=1 … Sun=7
+    days_since_sunday = today.isoweekday() % 7  # Sun→0, Mon→1, …, Sat→6
+    week_start = today - timedelta(days=days_since_sunday)
+    week_end = week_start + timedelta(days=6)  # Saturday
+    return week_start, week_end
+
+
 def generate_page(
     memories: list[Memory],
     today: date,
@@ -117,9 +130,9 @@ def generate_page(
     if template is None:
         template = _DEFAULT_TEMPLATE.read_text()
 
-    week_end = today + timedelta(days=(6 - today.weekday()))
+    week_start, week_end = week_bounds(today)
 
-    this_week = [m for m in memories if m.target is None or m.target <= week_end]
+    this_week = [m for m in memories if m.target is None or (week_start <= m.target <= week_end)]
     future = [m for m in memories if m.target is not None and m.target > week_end]
 
     def render_section(title: str, events: list[Memory]) -> str:


### PR DESCRIPTION
## Summary
- Changed week boundaries from Monday-Sunday to Sunday-Saturday in both the Python publisher and the client-side JS
- Added a `week_start` lower bound so events from the previous week are excluded from "This Week" on Sunday
- Extracted a unit-testable `week_bounds()` helper in the publisher and `weekStart()`/`weekEnd()` in the client

## Details
The root cause was that the week boundary calculation used Python's `weekday()` (Monday=0), making weeks run Mon→Sun. On Sunday, `week_end = today`, so all previous Mon–Sat events were still `<= week_end` and appeared in "This Week".

The fix uses `isoweekday() % 7` to make Sunday=0, giving Sun→Sat weeks. A new `week_start` bound filters out events before the current week.

## Test plan
- [x] Added `test_week_bounds_sunday/wednesday/saturday/monday` — verifies correct boundaries for each day
- [x] Added `test_this_week_resets_on_sunday` — directly tests the bug scenario
- [x] All 92 existing tests pass

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)