### PR TITLE
Rename project branding to Event Ledger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Living Memory is a static website generator similar to a CMS. It supports two storage backends: **file-based** (markdown files in a git repo) and **Firestore** (Google Cloud Firestore documents). The file-based backend is the default; Firestore can be enabled via the `--firestore` CLI flag or by setting `LIVING_MEMORY_STORAGE=firestore`.
+Event Ledger is a static website generator similar to a CMS. It supports two storage backends: **file-based** (markdown files in a git repo) and **Firestore** (Google Cloud Firestore documents). The file-based backend is the default; Firestore can be enabled via the `--firestore` CLI flag or by setting `LIVING_MEMORY_STORAGE=firestore`.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Living Memory
+# Event Ledger
 
 A family events page backed by Firestore. The **GitHub Pages homepage** is a client-rendered page (`client/index.html`) that reads memories directly from Firestore in the browser — no server-side build required.
 

--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Our Church Events</title>
+<title>Event Ledger</title>
 <style>
   body { font-family: system-ui, sans-serif; max-width: 640px; margin: 2rem auto; padding: 0 1rem; }
   h1 { border-bottom: 2px solid #333; padding-bottom: 0.5rem; }
@@ -23,7 +23,7 @@
 </style>
 </head>
 <body>
-<h1>Our Church Events</h1>
+<h1>Event Ledger</h1>
 <div class="authbar">
   <button id="signin" type="button">Sign in with Google</button>
   <button id="signin-redirect" type="button" style="display:none">Sign in (redirect)</button>


### PR DESCRIPTION
## Summary
- Rename visible project name from "Living Memory" / "Our Church Events" to **Event Ledger**
- Updated `client/index.html` (`<title>` and `<h1>`), `README.md` heading, and `CLAUDE.md` project overview
- Repo name, package names, env vars, and GitHub Pages path are unchanged

## Test plan
- [ ] Verify GitHub Pages deploy succeeds
- [ ] Confirm client page shows "Event Ledger" as title and heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)