### PR TITLE
Add HTTP API for Cloud Run deployment

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,46 @@
+name: Deploy API to Cloud Run
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Dockerfile'
+      - 'pyproject.toml'
+      - '.github/workflows/deploy-api.yml'
+
+env:
+  PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}         # e.g. living-memories-488001
+  REGION: ${{ vars.GCP_REGION || 'us-east1' }}
+  SERVICE: ${{ vars.CLOUD_RUN_SERVICE || 'event-ledger-api' }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # for Workload Identity Federation
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}  # e.g. projects/123/locations/global/workloadIdentityPools/github/providers/github
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}      # e.g. github-actions@project.iam.gserviceaccount.com
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build and push container
+        run: |
+          gcloud builds submit --tag "gcr.io/$PROJECT_ID/$SERVICE"
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy "$SERVICE" \
+            --image "gcr.io/$PROJECT_ID/$SERVICE" \
+            --region "$REGION" \
+            --platform managed \
+            --allow-unauthenticated \
+            --set-env-vars "EVENT_LEDGER_API_KEY=${{ secrets.EVENT_LEDGER_API_KEY }},EVENT_LEDGER_USER_ID=${{ vars.EVENT_LEDGER_USER_ID || 'cambridge-lexington' }},GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }},GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }},LIVING_MEMORY_FIRESTORE_DATABASE=${{ vars.FIRESTORE_DATABASE || 'living-memories-db' }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml .
+COPY src/ src/
+
+RUN pip install --no-cache-dir . fastapi uvicorn[standard]
+
+EXPOSE 8080
+
+CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "google-cloud-firestore>=2.0.0",
     "python-dotenv>=1.0.0",
     "markdown>=3.5",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.30.0",
 ]
 
 [project.scripts]
@@ -20,6 +22,7 @@ cleanup = "cleanup:main"
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
+    "httpx>=0.27.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,64 @@
+"""HTTP API for Event Ledger — deployed to Cloud Run."""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import Depends, FastAPI, HTTPException, Header
+from pydantic import BaseModel
+
+import firestore_storage
+from committer import commit_memory_firestore
+
+app = FastAPI(title="Event Ledger API")
+
+API_KEY = os.environ.get("EVENT_LEDGER_API_KEY", "")
+USER_ID = os.environ.get("EVENT_LEDGER_USER_ID", "default")
+
+
+def _check_auth(authorization: str = Header(...)) -> None:
+    if not API_KEY:
+        raise HTTPException(status_code=500, detail="API key not configured")
+    if authorization != f"Bearer {API_KEY}":
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+class CreateMemoryRequest(BaseModel):
+    message: str
+    attachments: list[str] | None = None
+
+
+@app.get("/healthz")
+def healthz():
+    return {"ok": True}
+
+
+@app.post("/memories", dependencies=[Depends(_check_auth)])
+def create_memory(body: CreateMemoryRequest):
+    result = commit_memory_firestore(
+        message=body.message,
+        user_id=USER_ID,
+        attachment_urls=body.attachments,
+    )
+    return {
+        "action": result.action,
+        "id": result.doc_id,
+        "memory": result.memory.to_dict(),
+    }
+
+
+@app.get("/memories", dependencies=[Depends(_check_auth)])
+def list_memories():
+    pairs = firestore_storage.load_memories(USER_ID)
+    return {
+        "memories": [
+            {"id": doc_id, **mem.to_dict()}
+            for doc_id, mem in pairs
+        ],
+    }
+
+
+@app.delete("/memories/{memory_id}", dependencies=[Depends(_check_auth)])
+def delete_memory(memory_id: str):
+    firestore_storage.delete_memory(memory_id)
+    return {"ok": True}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,139 @@
+"""Tests for the HTTP API."""
+
+from datetime import date
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memory import Memory
+from committer import CommitResult
+
+
+@pytest.fixture(autouse=True)
+def _set_api_key(monkeypatch):
+    monkeypatch.setenv("EVENT_LEDGER_API_KEY", "test-key")
+    monkeypatch.setenv("EVENT_LEDGER_USER_ID", "test-user")
+    # Re-import to pick up env vars
+    import api
+    api.API_KEY = "test-key"
+    api.USER_ID = "test-user"
+
+
+@pytest.fixture
+def client():
+    from api import app
+    return TestClient(app)
+
+
+AUTH = {"Authorization": "Bearer test-key"}
+
+
+# --- Auth tests ---
+
+def test_healthz_no_auth(client):
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_list_memories_no_auth(client):
+    resp = client.get("/memories")
+    assert resp.status_code == 422  # missing header
+
+
+def test_list_memories_bad_key(client):
+    resp = client.get("/memories", headers={"Authorization": "Bearer wrong"})
+    assert resp.status_code == 401
+
+
+def test_create_memory_no_auth(client):
+    resp = client.post("/memories", json={"message": "hi"})
+    assert resp.status_code == 422
+
+
+def test_create_memory_bad_key(client):
+    resp = client.post("/memories", json={"message": "hi"},
+                       headers={"Authorization": "Bearer wrong"})
+    assert resp.status_code == 401
+
+
+# --- POST /memories ---
+
+@patch("api.commit_memory_firestore")
+def test_create_memory(mock_commit, client):
+    mem = Memory(
+        target=date(2026, 3, 5),
+        expires=date(2026, 4, 4),
+        content="Weekly planning session",
+        title="Team Meeting",
+        time="10:00",
+        place="Room A",
+        user_id="test-user",
+    )
+    mock_commit.return_value = CommitResult(
+        action="created", doc_id="abc123", memory=mem,
+    )
+
+    resp = client.post("/memories", json={"message": "Team meeting Thursday 10am"},
+                       headers=AUTH)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["action"] == "created"
+    assert data["id"] == "abc123"
+    assert data["memory"]["title"] == "Team Meeting"
+
+    mock_commit.assert_called_once_with(
+        message="Team meeting Thursday 10am",
+        user_id="test-user",
+        attachment_urls=None,
+    )
+
+
+@patch("api.commit_memory_firestore")
+def test_create_memory_with_attachments(mock_commit, client):
+    mem = Memory(
+        target=date(2026, 3, 5), expires=date(2026, 4, 4),
+        content="Event", title="Test", user_id="test-user",
+    )
+    mock_commit.return_value = CommitResult(
+        action="created", doc_id="xyz", memory=mem,
+    )
+
+    resp = client.post("/memories",
+                       json={"message": "hi", "attachments": ["https://example.com/a.png"]},
+                       headers=AUTH)
+    assert resp.status_code == 200
+    mock_commit.assert_called_once_with(
+        message="hi",
+        user_id="test-user",
+        attachment_urls=["https://example.com/a.png"],
+    )
+
+
+# --- GET /memories ---
+
+@patch("api.firestore_storage")
+def test_list_memories(mock_fs, client):
+    mem = Memory(
+        target=date(2026, 3, 5), expires=date(2026, 4, 4),
+        content="Hello", title="Test Event", user_id="test-user",
+    )
+    mock_fs.load_memories.return_value = [("doc1", mem)]
+
+    resp = client.get("/memories", headers=AUTH)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["memories"]) == 1
+    assert data["memories"][0]["id"] == "doc1"
+    assert data["memories"][0]["title"] == "Test Event"
+
+
+# --- DELETE /memories/{id} ---
+
+@patch("api.firestore_storage")
+def test_delete_memory(mock_fs, client):
+    resp = client.delete("/memories/doc1", headers=AUTH)
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    mock_fs.delete_memory.assert_called_once_with("doc1")


### PR DESCRIPTION
## Summary
- Add FastAPI HTTP API (`src/api.py`) with static Bearer token auth (`EVENT_LEDGER_API_KEY`)
- Endpoints: `GET /healthz`, `POST /memories`, `GET /memories`, `DELETE /memories/{id}`
- Refactor `committer.py` to expose `commit_memory_firestore()` for programmatic use
- Add `Dockerfile` for Cloud Run and `deploy-api.yml` GitHub Actions workflow (template)
- 9 new API tests covering auth and all CRUD flows (all 112 tests pass)
- Update README with curl examples, env vars, and deployment docs

## Test plan
- [x] All existing tests still pass (112 total)
- [x] New API tests cover: no-auth rejection, bad-key rejection, memory creation, creation with attachments, listing, deletion
- [ ] Manual test: deploy to Cloud Run and verify endpoints with curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)