### PR TITLE
Fix Cloud Run 404: correct uvicorn module path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN pip install --no-cache-dir . fastapi uvicorn[standard]
 
 EXPOSE 8080
 
-CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "src.api:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## Summary
- Dockerfile CMD used `api:app` which doesn't resolve because the module lives under `src/`
- Changed to `src.api:app` so uvicorn can find the FastAPI app

## Test plan
- [ ] Deploy to Cloud Run and verify `GET /healthz` returns 200
- [ ] Verify `POST /memories` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)