### PR TITLE
Add /_healthz to avoid Cloud Run edge 404

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ EVENT_LEDGER_API_KEY=dev-key GEMINI_API_KEY=... \
   .venv/bin/uvicorn api:app --app-dir src --reload
 ```
 
-Endpoints: `GET /healthz`, `POST /memories`, `GET /memories`, `DELETE /memories/{id}`. All except `/healthz` require `Authorization: Bearer <key>`. Deployed to Cloud Run via `.github/workflows/deploy-api.yml`.
+Endpoints: `GET /_healthz`, `POST /memories`, `GET /memories`, `DELETE /memories/{id}`. Legacy alias `GET /healthz` also works. All except `/healthz` require `Authorization: Bearer <key>`. Deployed to Cloud Run via `.github/workflows/deploy-api.yml`.
 
 ## Client-Side Page
 

--- a/src/api.py
+++ b/src/api.py
@@ -28,6 +28,7 @@ class CreateMemoryRequest(BaseModel):
     attachments: list[str] | None = None
 
 
+@app.get("/_healthz")
 @app.get("/healthz")
 def healthz():
     return {"ok": True}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,6 +32,12 @@ AUTH = {"Authorization": "Bearer test-key"}
 # --- Auth tests ---
 
 def test_healthz_no_auth(client):
+    resp = client.get("/_healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_healthz_legacy_alias(client):
     resp = client.get("/healthz")
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}


### PR DESCRIPTION
## Summary
- Add `GET /_healthz` as primary health check endpoint to work around Cloud Run infrastructure intercepting `/healthz` with an HTML 404
- Keep `GET /healthz` as a legacy alias so existing integrations continue to work
- Update tests and docs to reference `/_healthz`

## Test plan
- [x] `test_healthz_no_auth` now hits `/_healthz`
- [x] New `test_healthz_legacy_alias` confirms `/healthz` still works
- [x] All 10 API tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)