### PR TITLE
Disable Cloud Run deploy workflow on push

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,13 +1,8 @@
+# Template: requires GCP auth (WIF or credentials_json).
 name: Deploy API to Cloud Run
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'src/**'
-      - 'Dockerfile'
-      - 'pyproject.toml'
-      - '.github/workflows/deploy-api.yml'
+  workflow_dispatch:
 
 env:
   PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}         # e.g. living-memories-488001


### PR DESCRIPTION
## Summary
- Switch deploy-api.yml trigger from `push` to `workflow_dispatch` only
- Adds comment noting GCP auth requirements
- Prevents CI failures when GCP auth secrets are not configured

## Test plan
- [x] Other workflows (publish, cleanup) unchanged
- [ ] Verify no deploy job runs on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)