### PR TITLE
Add Cloud Run deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ The API emits structured logs viewable in Cloud Run's **Logs Explorer**. Each re
 ## Deploy
 
 - **GitHub Pages** — see `.github/workflows/publish.yml`
-- **Cloud Run API** — see `.github/workflows/deploy-api.yml`
+- **Cloud Run API** — `./scripts/deploy_cloud_run.sh` (or see `.github/workflows/deploy-api.yml` for CI)

--- a/scripts/deploy_cloud_run.sh
+++ b/scripts/deploy_cloud_run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT="living-memories-488001"
+REGION="northamerica-northeast1"
+SERVICE="event-ledger-api"
+
+echo "Deploying ${SERVICE} to Cloud Run (${PROJECT} / ${REGION})..."
+
+gcloud run deploy "${SERVICE}" \
+  --project "${PROJECT}" \
+  --region "${REGION}" \
+  --source . \
+  --set-env-vars "EVENT_LEDGER_USER_ID=cambridge-lexington,GOOGLE_CLOUD_PROJECT=${PROJECT},LIVING_MEMORY_FIRESTORE_DATABASE=(default)"
+
+SERVICE_URL=$(gcloud run services describe "${SERVICE}" \
+  --project "${PROJECT}" \
+  --region "${REGION}" \
+  --format "value(status.url)")
+
+echo ""
+echo "Deployed successfully: ${SERVICE_URL}"


### PR DESCRIPTION
## Summary
- Add `scripts/deploy_cloud_run.sh` for one-command Cloud Run deploys
- Sets project, region, service, and non-secret env vars; skips `EVENT_LEDGER_API_KEY` (managed via Secret Manager)
- Update README deploy section to reference the script

## Test plan
- [ ] Run `./scripts/deploy_cloud_run.sh` against the target GCP project
- [ ] Verify service URL is printed and reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)