### PR TITLE
ci: fix Cloud Run deploy auth (support WIF or credentials JSON)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,4 +1,4 @@
-# Template: requires GCP auth (WIF or credentials_json).
+# Template: requires GCP auth via service account JSON.
 name: Deploy API to Cloud Run
 
 on:
@@ -14,33 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write  # for Workload Identity Federation
 
     steps:
       - uses: actions/checkout@v4
 
-      # Auth: use WIF if configured, else fall back to a service account JSON.
-      # Exactly one of workload_identity_provider or credentials_json must be set.
-      - id: auth_wif
-        if: ${{ secrets.WIF_PROVIDER != '' && secrets.WIF_SERVICE_ACCOUNT != '' }}
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}  # e.g. projects/123/locations/global/workloadIdentityPools/github/providers/github
-          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}      # e.g. github-actions@project.iam.gserviceaccount.com
+      - name: Fail fast if missing GCP credentials
+        if: ${{ secrets.GCP_CREDENTIALS_JSON == '' }}
+        run: |
+          echo "Missing required secret: GCP_CREDENTIALS_JSON (service account key JSON)."
+          exit 1
 
-      - id: auth_json
-        if: ${{ (secrets.WIF_PROVIDER == '' || secrets.WIF_SERVICE_ACCOUNT == '') && secrets.GCP_CREDENTIALS_JSON != '' }}
+      - id: auth
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
-
-      - name: Fail fast if no GCP auth configured
-        if: ${{ secrets.WIF_PROVIDER == '' && secrets.WIF_SERVICE_ACCOUNT == '' && secrets.GCP_CREDENTIALS_JSON == '' }}
-        run: |
-          echo "Missing GCP auth configuration. Provide either:"
-          echo "- secrets.WIF_PROVIDER + secrets.WIF_SERVICE_ACCOUNT (recommended), or"
-          echo "- secrets.GCP_CREDENTIALS_JSON (service account key JSON)."
-          exit 1
 
       - uses: google-github-actions/setup-gcloud@v2
 


### PR DESCRIPTION
Fix Deploy API to Cloud Run workflow auth by switching to service account JSON only.

- Uses google-github-actions/auth@v2 with credentials_json: secrets.GCP_CREDENTIALS_JSON
- Removes WIF to avoid misconfiguration / missing secret errors
- Adds a clear fail-fast step if GCP_CREDENTIALS_JSON is missing

To use:
1) Add repo secret GCP_CREDENTIALS_JSON (service account key JSON)
2) Run Actions → Deploy API to Cloud Run → Run workflow