### PR TITLE
ci: fix deploy-api Cloud Build step by suppressing log streaming

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -28,7 +28,9 @@ jobs:
 
       - name: Build and push container
         run: |
-          gcloud builds submit --tag "gcr.io/$PROJECT_ID/$SERVICE"
+          # gcloud can fail if it cannot stream logs (e.g. VPC-SC / logs bucket perms).
+          # Suppress log streaming; logs remain available in Cloud Console.
+          gcloud builds submit --tag "gcr.io/$PROJECT_ID/$SERVICE" --suppress-logs
 
       - name: Deploy to Cloud Run
         run: |


### PR DESCRIPTION
The Deploy API to Cloud Run workflow was failing even though the build started successfully, due to gcloud being unable to stream logs (VPC-SC / logs bucket permissions).

This adds --suppress-logs to gcloud builds submit so the command doesn't fail just because it can't stream logs. Logs remain available in Cloud Console via the build URL.