### PR TITLE
feat: add memory input box for page owners

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -94,3 +94,15 @@ export async function getPageMemories(slug: string): Promise<MemoryItem[]> {
   const data = await resp.json();
   return data.memories;
 }
+
+export async function createMemory(
+  slug: string,
+  message: string,
+): Promise<{ action: string; id: string; memory: MemoryItem }> {
+  const resp = await apiFetch(`/api/pages/${slug}/memories`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message }),
+  });
+  return resp.json();
+}

--- a/web/src/components/AddMemoryForm.tsx
+++ b/web/src/components/AddMemoryForm.tsx
@@ -1,0 +1,54 @@
+import { useState, type FormEvent } from "react";
+import { createMemory } from "../api";
+
+interface AddMemoryFormProps {
+  slug: string;
+  onSuccess: () => void;
+}
+
+export function AddMemoryForm({ slug, onSuccess }: AddMemoryFormProps) {
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const text = message.trim();
+    if (!text) return;
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      await createMemory(slug, text);
+      setMessage("");
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add memory");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form className="add-memory-form" onSubmit={handleSubmit}>
+      <div className="add-memory-input-row">
+        <input
+          type="text"
+          className="add-memory-input"
+          placeholder="What do you want to add to the events?"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          disabled={submitting}
+        />
+        <button
+          type="submit"
+          className="btn btn-primary"
+          disabled={submitting || !message.trim()}
+        >
+          {submitting ? "Adding..." : "Add"}
+        </button>
+      </div>
+      {error && <p className="add-memory-error">{error}</p>}
+    </form>
+  );
+}

--- a/web/src/routes/PageView.tsx
+++ b/web/src/routes/PageView.tsx
@@ -6,12 +6,15 @@ import {
   type PageSummary,
   type MemoryItem,
 } from "../api";
+import { useAuth } from "../auth";
 import { LoadingSpinner } from "../components/LoadingSpinner";
 import { ErrorMessage } from "../components/ErrorMessage";
 import { MemoryList } from "../components/MemoryList";
+import { AddMemoryForm } from "../components/AddMemoryForm";
 
 export function PageView() {
   const { slug } = useParams<{ slug: string }>();
+  const { user } = useAuth();
   const [page, setPage] = useState<PageSummary | null>(null);
   const [memories, setMemories] = useState<MemoryItem[] | null>(null);
   const [loading, setLoading] = useState(true);
@@ -60,6 +63,10 @@ export function PageView() {
         <MemoryList memories={memories} />
       ) : (
         <p className="placeholder">No upcoming events on this page.</p>
+      )}
+
+      {slug && user && page?.owner_uids.includes(user.uid) && (
+        <AddMemoryForm slug={slug} onSuccess={load} />
       )}
     </div>
   );

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -224,3 +224,40 @@ h2 {
 .attachments a {
   margin-right: 0.5rem;
 }
+
+/* Add memory form */
+.add-memory-form {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #eee;
+}
+
+.add-memory-input-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.add-memory-input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.add-memory-input:focus {
+  outline: none;
+  border-color: #333;
+}
+
+.add-memory-input:disabled {
+  background: #f5f5f5;
+  color: #999;
+}
+
+.add-memory-error {
+  color: #c00;
+  font-size: 0.9rem;
+  margin: 0.5rem 0 0;
+}


### PR DESCRIPTION
## Summary
- Adds an input form to the page view so owners can create memories directly from the UI
- Only visible to page owners (checks `user.uid` against `page.owner_uids`)
- Calls the existing `POST /pages/{slug}/memories` endpoint and refreshes the memory list on success

Closes #33

## Test plan
- [ ] Non-owners see no input box on the page
- [ ] Owners see the input box at the bottom of the page
- [ ] Submitting text calls the API and refreshes the memory list
- [ ] Error states display correctly
- [ ] Loading state disables the form during submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)