### PR TITLE
fix: redirect back to original page after sign-in

### DIFF
--- a/web/src/routes/SignIn.tsx
+++ b/web/src/routes/SignIn.tsx
@@ -1,20 +1,22 @@
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "../auth";
 import { getMe } from "../api";
 
 export function SignIn() {
   const { user, loading, signIn } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as { from?: { pathname: string } })?.from?.pathname || "/dashboard";
 
   useEffect(() => {
     if (!loading && user) {
-      // Ensure user profile exists in backend, then go to dashboard
+      // Ensure user profile exists in backend, then redirect back
       getMe()
-        .then(() => navigate("/dashboard", { replace: true }))
-        .catch(() => navigate("/dashboard", { replace: true }));
+        .then(() => navigate(from, { replace: true }))
+        .catch(() => navigate(from, { replace: true }));
     }
-  }, [user, loading, navigate]);
+  }, [user, loading, navigate, from]);
 
   if (loading) {
     return <div className="loading-screen">Loading...</div>;


### PR DESCRIPTION
## Summary
- After sign-in, redirect the user back to the page they were trying to visit instead of always going to `/dashboard`
- `RequireAuth` already saved the original location in router state — `SignIn` now reads it

Closes #54

## Test plan
- [ ] Navigate to `/p/cambridge-lexington` while signed out
- [ ] Sign in — should redirect back to `/p/cambridge-lexington`, not `/dashboard`
- [ ] Navigate directly to `/sign-in` and sign in — should still go to `/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)