### PR TITLE
fix: add permissions for deploy-preview workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ on:
       - 'web/**'
       - '.github/workflows/publish.yml'
 
+permissions:
+  checks: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `checks: write` and `pull-requests: write` permissions to the Deploy Web App workflow
- Fixes the `deploy-preview` job failing with 403 "Resource not accessible by integration" on PRs

## Test plan
- [ ] This PR itself should trigger a successful deploy-preview run

🤖 Generated with [Claude Code](https://claude.com/claude-code)