### PR TITLE
fix: use query param for post-sign-in redirect (#54)

### DIFF
--- a/web/src/auth.tsx
+++ b/web/src/auth.tsx
@@ -73,7 +73,8 @@ export function RequireAuth({ children }: { children: ReactNode }) {
   }
 
   if (!user) {
-    return <Navigate to="/sign-in" state={{ from: location }} replace />;
+    const redirect = `/sign-in?redirect=${encodeURIComponent(location.pathname)}`;
+    return <Navigate to={redirect} replace />;
   }
 
   return <>{children}</>;

--- a/web/src/routes/SignIn.tsx
+++ b/web/src/routes/SignIn.tsx
@@ -1,22 +1,22 @@
 import { useEffect } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useAuth } from "../auth";
 import { getMe } from "../api";
 
 export function SignIn() {
   const { user, loading, signIn } = useAuth();
   const navigate = useNavigate();
-  const location = useLocation();
-  const from = (location.state as { from?: { pathname: string } })?.from?.pathname || "/dashboard";
+  const [searchParams] = useSearchParams();
+  const redirect = searchParams.get("redirect") || "/dashboard";
 
   useEffect(() => {
     if (!loading && user) {
       // Ensure user profile exists in backend, then redirect back
       getMe()
-        .then(() => navigate(from, { replace: true }))
-        .catch(() => navigate(from, { replace: true }));
+        .then(() => navigate(redirect, { replace: true }))
+        .catch(() => navigate(redirect, { replace: true }));
     }
-  }, [user, loading, navigate, from]);
+  }, [user, loading, navigate, redirect]);
 
   if (loading) {
     return <div className="loading-screen">Loading...</div>;


### PR DESCRIPTION
## Summary
- Replace router state-based redirect with a `?redirect=` query parameter
- `RequireAuth` now redirects to `/sign-in?redirect=%2Fp%2Fslug` instead of passing hidden router state
- `SignIn` reads the query param and redirects back after authentication
- Falls back to `/dashboard` when no redirect param is present

The previous approach using React Router's `location.state` was unreliable — the state was being lost, causing all sign-ins to land on `/dashboard`.

Closes #54

## Test plan
- [ ] Go to `/p/cambridge-lexington` while signed out → should redirect to `/sign-in?redirect=%2Fp%2Fcambridge-lexington`
- [ ] Sign in → should redirect back to `/p/cambridge-lexington`
- [ ] Go directly to `/sign-in` and sign in → should go to `/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)