### PR TITLE
feat: add page creation UI to dashboard (#65)

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -191,6 +191,14 @@ def create_page(body: CreatePageRequest, uid: str = Depends(_get_uid)):
         created = page_storage.create_page(page)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+
+    # Auto-set default_personal_page_id if this is a personal page
+    if body.visibility == "personal":
+        user = page_storage.get_user(uid)
+        if user is None or user.default_personal_page_id is None:
+            page_storage.get_or_create_user(uid)
+            page_storage.update_user(uid, {"default_personal_page_id": body.slug})
+
     logger.info("create_page slug=%s uid=%s", body.slug, uid)
     return {"page": {**created.to_dict(), "slug": created.slug}}
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -95,6 +95,21 @@ export async function getPageMemories(slug: string): Promise<MemoryItem[]> {
   return data.memories;
 }
 
+export async function createPage(
+  slug: string,
+  title: string,
+  visibility: string,
+  description?: string,
+): Promise<PageSummary> {
+  const resp = await apiFetch("/api/pages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ slug, title, visibility, description }),
+  });
+  const data = await resp.json();
+  return data.page;
+}
+
 export async function createMemory(
   slug: string,
   message: string,

--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -1,15 +1,45 @@
 import { useEffect, useState, useCallback } from "react";
-import { Link } from "react-router-dom";
-import { getMe, getMyPages, type UserProfile, type PageSummary } from "../api";
+import { Link, useNavigate } from "react-router-dom";
+import {
+  getMe,
+  getMyPages,
+  createPage,
+  type UserProfile,
+  type PageSummary,
+} from "../api";
+import { auth } from "../firebase";
 import { LoadingSpinner } from "../components/LoadingSpinner";
 import { ErrorMessage } from "../components/ErrorMessage";
 import { PageCard } from "../components/PageCard";
 
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
 export function Dashboard() {
+  const navigate = useNavigate();
   const [user, setUser] = useState<UserProfile | null>(null);
   const [pages, setPages] = useState<PageSummary[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+
+  // Personal page creation
+  const [creatingPersonal, setCreatingPersonal] = useState(false);
+
+  // Create page form
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [formTitle, setFormTitle] = useState("");
+  const [formSlug, setFormSlug] = useState("");
+  const [formSlugTouched, setFormSlugTouched] = useState(false);
+  const [formVisibility, setFormVisibility] = useState<"public" | "personal">(
+    "public",
+  );
+  const [formSubmitting, setFormSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -29,6 +59,47 @@ export function Dashboard() {
     load();
   }, [load]);
 
+  async function handleCreatePersonalPage() {
+    const uid = auth.currentUser?.uid;
+    if (!uid) return;
+    setCreatingPersonal(true);
+    try {
+      const slug = `personal-${uid}`;
+      await createPage(slug, "Personal Page", "personal");
+      navigate(`/p/${slug}`);
+    } catch (err) {
+      setError(err as Error);
+      setCreatingPersonal(false);
+    }
+  }
+
+  function handleTitleChange(value: string) {
+    setFormTitle(value);
+    if (!formSlugTouched) {
+      setFormSlug(slugify(value));
+    }
+  }
+
+  async function handleCreatePage(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!formSlug || !formTitle) return;
+    setFormSubmitting(true);
+    setFormError(null);
+    try {
+      await createPage(formSlug, formTitle, formVisibility);
+      setShowCreateForm(false);
+      setFormTitle("");
+      setFormSlug("");
+      setFormSlugTouched(false);
+      setFormVisibility("public");
+      await load();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Failed to create page");
+    } finally {
+      setFormSubmitting(false);
+    }
+  }
+
   if (loading) return <LoadingSpinner message="Loading dashboard..." />;
   if (error) return <ErrorMessage error={error} onRetry={load} />;
 
@@ -44,13 +115,107 @@ export function Dashboard() {
           </p>
         ) : (
           <p className="placeholder">
-            You don't have a personal page yet.
+            You don't have a personal page yet.{" "}
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={handleCreatePersonalPage}
+              disabled={creatingPersonal}
+            >
+              {creatingPersonal ? "Creating..." : "Create Personal Page"}
+            </button>
           </p>
         )}
       </section>
 
       <section className="section">
-        <h2>My Pages</h2>
+        <div className="section-header">
+          <h2>My Pages</h2>
+          {!showCreateForm && (
+            <button
+              className="btn btn-secondary btn-sm"
+              onClick={() => setShowCreateForm(true)}
+            >
+              Create Page
+            </button>
+          )}
+        </div>
+
+        {showCreateForm && (
+          <form className="create-page-form" onSubmit={handleCreatePage}>
+            <div className="form-field">
+              <label htmlFor="page-title">Title</label>
+              <input
+                id="page-title"
+                type="text"
+                className="form-input"
+                value={formTitle}
+                onChange={(e) => handleTitleChange(e.target.value)}
+                placeholder="My new page"
+                required
+                disabled={formSubmitting}
+              />
+            </div>
+            <div className="form-field">
+              <label htmlFor="page-slug">Slug</label>
+              <input
+                id="page-slug"
+                type="text"
+                className="form-input"
+                value={formSlug}
+                onChange={(e) => {
+                  setFormSlug(e.target.value);
+                  setFormSlugTouched(true);
+                }}
+                placeholder="my-new-page"
+                required
+                disabled={formSubmitting}
+              />
+            </div>
+            <div className="form-field">
+              <label>Visibility</label>
+              <div className="visibility-toggle">
+                <button
+                  type="button"
+                  className={`btn btn-sm ${formVisibility === "public" ? "btn-primary" : "btn-secondary"}`}
+                  onClick={() => setFormVisibility("public")}
+                  disabled={formSubmitting}
+                >
+                  Public
+                </button>
+                <button
+                  type="button"
+                  className={`btn btn-sm ${formVisibility === "personal" ? "btn-primary" : "btn-secondary"}`}
+                  onClick={() => setFormVisibility("personal")}
+                  disabled={formSubmitting}
+                >
+                  Personal
+                </button>
+              </div>
+            </div>
+            {formError && <p className="form-error">{formError}</p>}
+            <div className="form-actions">
+              <button
+                type="submit"
+                className="btn btn-primary btn-sm"
+                disabled={formSubmitting || !formTitle || !formSlug}
+              >
+                {formSubmitting ? "Creating..." : "Create"}
+              </button>
+              <button
+                type="button"
+                className="btn btn-secondary btn-sm"
+                onClick={() => {
+                  setShowCreateForm(false);
+                  setFormError(null);
+                }}
+                disabled={formSubmitting}
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        )}
+
         {pages && pages.length > 0 ? (
           <ul className="page-list">
             {pages.map((page) => (
@@ -58,7 +223,7 @@ export function Dashboard() {
             ))}
           </ul>
         ) : (
-          <p className="placeholder">No pages yet.</p>
+          !showCreateForm && <p className="placeholder">No pages yet.</p>
         )}
       </section>
     </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -261,3 +261,75 @@ h2 {
   font-size: 0.9rem;
   margin: 0.5rem 0 0;
 }
+
+/* Small button variant */
+.btn-sm {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+/* Section header with inline button */
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.section-header h2 {
+  margin: 0;
+}
+
+/* Create page form */
+.create-page-form {
+  margin: 1rem 0;
+  padding: 1rem;
+  background: #f8f8f8;
+  border-radius: 6px;
+}
+
+.form-field {
+  margin-bottom: 0.75rem;
+}
+
+.form-field label {
+  display: block;
+  font-size: 0.85rem;
+  color: #555;
+  margin-bottom: 0.25rem;
+}
+
+.form-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-family: system-ui, -apple-system, sans-serif;
+  box-sizing: border-box;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #333;
+}
+
+.form-input:disabled {
+  background: #f0f0f0;
+  color: #999;
+}
+
+.visibility-toggle {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.form-error {
+  color: #c00;
+  font-size: 0.9rem;
+  margin: 0 0 0.75rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- Add `createPage` API function in `web/src/api.ts` to call `POST /api/pages`
- Add "Create Personal Page" button to Dashboard when user has no personal page (creates `personal-{uid}` slug and navigates to it)
- Add inline "Create Page" form in My Pages section with title, auto-generated slug, and visibility toggle
- Backend `create_page` endpoint now auto-sets `default_personal_page_id` on user document for personal pages

## Test plan
- [x] `npm run build` passes (no TypeScript errors)
- [x] `.venv/bin/pytest` passes (124 tests)
- [ ] Manual: sign in → dashboard → click "Create Personal Page" → verify redirect to new page
- [ ] Manual: dashboard → click "Create Page" → fill form → verify page appears in My Pages

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)