### PR TITLE
fix: retry AI calls for complex unicode URL inputs

### DIFF
--- a/tests/test_committer.py
+++ b/tests/test_committer.py
@@ -123,3 +123,137 @@ def test_apply_user_urls_no_urls_is_noop():
     title, content = apply_user_urls("Title", "Content", [])
     assert title == "Title"
     assert content == "Content"
+
+
+# --- Unicode / complex URL tests (issue #74) ---
+
+UNICODE_URL = (
+    "https://www.stemofjesse.org/doku/doku.php/"
+    "%E6%99%A8%E5%85%B4%E5%9C%A3%E8%A8%80:2025:2025.05."
+    "%E7%A7%8B%E5%AD%A3%E9%95%BF%E8%80%81%E8%B4%9F%E8%B4%A3"
+    "%E5%BC%9F%E5%85%84%E8%AE%AD%E7%BB%83:%E7%AC%AC%E5%85%AD%E5%91%A8"
+)
+
+ISSUE_74_MESSAGE = f"本周晨兴链接 {UNICODE_URL}"
+
+
+def test_extract_urls_unicode_percent_encoded():
+    """URLs with percent-encoded Chinese characters and colons are extracted."""
+    urls = extract_urls(ISSUE_74_MESSAGE)
+    assert urls == [UNICODE_URL]
+
+
+def test_extract_urls_raw_unicode():
+    """URLs with raw (non-encoded) Chinese characters and colons are extracted."""
+    raw_url = "https://www.stemofjesse.org/doku/doku.php/晨兴圣言:2025:第六周"
+    urls = extract_urls(f"链接 {raw_url}")
+    assert urls == [raw_url]
+
+
+def test_apply_user_urls_unicode_url():
+    """apply_user_urls wraps title with a unicode URL correctly."""
+    title = "本周晨兴"
+    content = "晨兴圣言链接"
+    new_title, new_content = apply_user_urls(title, content, [UNICODE_URL])
+    assert new_title == f"[本周晨兴]({UNICODE_URL})"
+    assert UNICODE_URL in new_content
+
+
+def test_call_ai_retries_on_empty_response():
+    """call_ai retries when Gemini returns an empty response."""
+    mock_response_empty = MagicMock()
+    mock_response_empty.text = None
+
+    mock_response_ok = MagicMock()
+    mock_response_ok.text = '{"action": "create", "content": "test", "target": null, "expires": null, "title": "T"}'
+
+    mock_client = MagicMock()
+    mock_client.models.generate_content.side_effect = [mock_response_empty, mock_response_ok]
+
+    mock_genai = MagicMock()
+    mock_genai.Client.return_value = mock_client
+
+    mock_google = MagicMock()
+    mock_google.genai = mock_genai
+
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}), \
+         patch.dict(sys.modules, {"google": mock_google, "google.genai": mock_genai}):
+        from committer import call_ai
+        result = call_ai("test prompt")
+
+    assert result["action"] == "create"
+    assert mock_client.models.generate_content.call_count == 2
+
+
+def test_call_ai_retries_on_invalid_json():
+    """call_ai retries when Gemini returns invalid JSON."""
+    mock_response_bad = MagicMock()
+    mock_response_bad.text = "not valid json {"
+
+    mock_response_ok = MagicMock()
+    mock_response_ok.text = '{"action": "create", "content": "ok", "title": "T"}'
+
+    mock_client = MagicMock()
+    mock_client.models.generate_content.side_effect = [mock_response_bad, mock_response_ok]
+
+    mock_genai = MagicMock()
+    mock_genai.Client.return_value = mock_client
+
+    mock_google = MagicMock()
+    mock_google.genai = mock_genai
+
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}), \
+         patch.dict(sys.modules, {"google": mock_google, "google.genai": mock_genai}):
+        from committer import call_ai
+        result = call_ai("test prompt")
+
+    assert result["action"] == "create"
+    assert mock_client.models.generate_content.call_count == 2
+
+
+def test_call_ai_retries_on_missing_keys():
+    """call_ai retries when response JSON is missing required keys."""
+    mock_response_bad = MagicMock()
+    mock_response_bad.text = '{"title": "no action or content"}'
+
+    mock_response_ok = MagicMock()
+    mock_response_ok.text = '{"action": "create", "content": "ok", "title": "T"}'
+
+    mock_client = MagicMock()
+    mock_client.models.generate_content.side_effect = [mock_response_bad, mock_response_ok]
+
+    mock_genai = MagicMock()
+    mock_genai.Client.return_value = mock_client
+
+    mock_google = MagicMock()
+    mock_google.genai = mock_genai
+
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}), \
+         patch.dict(sys.modules, {"google": mock_google, "google.genai": mock_genai}):
+        from committer import call_ai
+        result = call_ai("test prompt")
+
+    assert result["action"] == "create"
+    assert mock_client.models.generate_content.call_count == 2
+
+
+def test_call_ai_raises_after_all_retries_exhausted():
+    """call_ai raises after all retry attempts fail."""
+    mock_response_empty = MagicMock()
+    mock_response_empty.text = None
+
+    mock_client = MagicMock()
+    mock_client.models.generate_content.return_value = mock_response_empty
+
+    mock_genai = MagicMock()
+    mock_genai.Client.return_value = mock_client
+
+    mock_google = MagicMock()
+    mock_google.genai = mock_genai
+
+    import pytest
+    with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}), \
+         patch.dict(sys.modules, {"google": mock_google, "google.genai": mock_genai}):
+        from committer import call_ai
+        with pytest.raises(ValueError, match="empty response"):
+            call_ai("test prompt")


### PR DESCRIPTION
## Summary

Fixes #74. Messages containing percent-encoded unicode URLs (like Chinese characters with colons in the path) could cause Gemini to return empty or malformed JSON, resulting in a 502 error for the user.

- Added retry logic (up to 2 attempts) in `call_ai()` for empty responses, invalid JSON, and missing required keys (`action`, `content`)
- Added logging for each retry attempt to aid debugging
- Validated AI response structure before returning

## Test plan

- [x] Added `test_extract_urls_unicode_percent_encoded` — verifies URL extraction for the exact failing message
- [x] Added `test_extract_urls_raw_unicode` — verifies URL extraction with raw (non-encoded) Chinese characters
- [x] Added `test_apply_user_urls_unicode_url` — verifies title wrapping with unicode URL
- [x] Added `test_call_ai_retries_on_empty_response` — verifies retry on `None` response
- [x] Added `test_call_ai_retries_on_invalid_json` — verifies retry on malformed JSON
- [x] Added `test_call_ai_retries_on_missing_keys` — verifies retry when required keys are absent
- [x] Added `test_call_ai_raises_after_all_retries_exhausted` — verifies error after all retries fail
- [x] Added `test_commit_chinese_message_with_unicode_url` — full integration test with the exact issue #74 message
- [x] All 135 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)