### PR TITLE
fix: replace URLs with placeholders before sending to Gemini (#74)

### DIFF
--- a/src/committer.py
+++ b/src/committer.py
@@ -33,6 +33,23 @@ def extract_urls(text: str) -> list[str]:
     return _URL_RE.findall(text)
 
 
+def replace_urls_with_placeholders(text: str) -> tuple[str, list[str]]:
+    """Replace URLs in *text* with numbered placeholders.
+
+    Returns ``(sanitised_text, urls)`` where each URL in the original is
+    replaced by ``[link1]``, ``[link2]``, etc.  The caller can later use
+    ``apply_user_urls`` to inject the real URLs back into the AI output.
+    """
+    urls: list[str] = []
+
+    def _sub(m: re.Match) -> str:
+        urls.append(m.group(0))
+        return f"[link{len(urls)}]"
+
+    sanitised = _URL_RE.sub(_sub, text)
+    return sanitised, urls
+
+
 def apply_user_urls(title: str | None, content: str, user_urls: list[str]) -> tuple[str, str]:
     """Post-process AI result to prefer user-provided URLs.
 
@@ -191,7 +208,10 @@ def commit_memory_firestore(
         pairs = firestore_storage.load_memories(user_id, today)
     existing_memories = [mem for _, mem in pairs]
 
-    prompt = build_ai_request(message, existing_memories, today,
+    # Replace complex URLs with placeholders so Gemini sees clean input.
+    sanitised_message, user_urls = replace_urls_with_placeholders(message)
+
+    prompt = build_ai_request(sanitised_message, existing_memories, today,
                               attachment_urls=attachment_urls or None)
     result = call_ai(prompt)
 
@@ -208,8 +228,7 @@ def commit_memory_firestore(
     expires = date.fromisoformat(raw_expires) if raw_expires else _next_sunday(today)
     raw_attachments = result.get("attachments")
 
-    # Prefer user-provided URLs over AI-generated ones
-    user_urls = extract_urls(message)
+    # Restore real URLs into AI output
     ai_title = result.get("title") or ""
     ai_content = result["content"]
     if user_urls:

--- a/tests/test_committer.py
+++ b/tests/test_committer.py
@@ -5,7 +5,7 @@ from datetime import date
 from unittest.mock import MagicMock, patch
 
 from memory import Memory
-from committer import apply_user_urls, build_ai_request, extract_urls
+from committer import apply_user_urls, build_ai_request, extract_urls, replace_urls_with_placeholders
 
 
 def test_build_ai_request():
@@ -157,6 +157,36 @@ def test_apply_user_urls_unicode_url():
     new_title, new_content = apply_user_urls(title, content, [UNICODE_URL])
     assert new_title == f"[本周晨兴]({UNICODE_URL})"
     assert UNICODE_URL in new_content
+
+
+def test_replace_urls_with_placeholders_basic():
+    text = "Check https://example.com/page for details"
+    sanitised, urls = replace_urls_with_placeholders(text)
+    assert sanitised == "Check [link1] for details"
+    assert urls == ["https://example.com/page"]
+
+
+def test_replace_urls_with_placeholders_multiple():
+    text = "See https://a.com and https://b.com/path"
+    sanitised, urls = replace_urls_with_placeholders(text)
+    assert sanitised == "See [link1] and [link2]"
+    assert urls == ["https://a.com", "https://b.com/path"]
+
+
+def test_replace_urls_with_placeholders_no_urls():
+    text = "No links here"
+    sanitised, urls = replace_urls_with_placeholders(text)
+    assert sanitised == "No links here"
+    assert urls == []
+
+
+def test_replace_urls_with_placeholders_unicode_url():
+    """Complex percent-encoded URLs are replaced with simple placeholders."""
+    sanitised, urls = replace_urls_with_placeholders(ISSUE_74_MESSAGE)
+    assert "[link1]" in sanitised
+    assert UNICODE_URL not in sanitised
+    assert "本周晨兴链接" in sanitised
+    assert urls == [UNICODE_URL]
 
 
 def test_call_ai_retries_on_empty_response():

--- a/tests/test_committer_firestore.py
+++ b/tests/test_committer_firestore.py
@@ -177,9 +177,10 @@ def test_commit_chinese_message_with_unicode_url(mock_call_ai, mock_load, mock_s
     # Content should include the URL
     assert UNICODE_URL in result.memory.content
 
-    # Verify the prompt sent to AI contains the full URL
+    # Verify the prompt sent to AI has the URL replaced with a placeholder
     prompt = mock_call_ai.call_args[0][0]
-    assert UNICODE_URL in prompt
+    assert UNICODE_URL not in prompt
+    assert "[link1]" in prompt
     assert "本周晨兴链接" in prompt
 
 


### PR DESCRIPTION
## Summary

- Instead of sending complex percent-encoded URLs (e.g. Chinese characters) directly to Gemini — which caused empty/malformed AI responses — replace URLs with `[link1]`, `[link2]` placeholders before building the prompt
- The existing `apply_user_urls()` restores the real URLs into the AI output afterward
- This is the proper fix for #74; the previous retry-based approach was a band-aid

## Test plan

- [x] `test_replace_urls_with_placeholders_basic` — single URL replaced
- [x] `test_replace_urls_with_placeholders_multiple` — multiple URLs replaced
- [x] `test_replace_urls_with_placeholders_no_urls` — no-op when no URLs
- [x] `test_replace_urls_with_placeholders_unicode_url` — complex percent-encoded URL replaced
- [x] `test_commit_chinese_message_with_unicode_url` — end-to-end: URL not in prompt, real URL restored in output
- [x] All 28 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)