### PR TITLE
feat(phase-1): data model redesign for pivot to scheduling platform

### DIFF
--- a/docs/migration-strategy.md
+++ b/docs/migration-strategy.md
@@ -1,0 +1,53 @@
+# Migration Strategy: Pages/Memories to Workspaces/Series/Occurrences
+
+## Overview
+
+The pivot introduces new top-level domain objects that replace the old Page and
+Memory models. Old collections remain read-only during the transition; no existing
+data is deleted until a migration script is explicitly run and verified.
+
+## Mapping: old to new
+
+| Old concept        | New concept                          | Notes                                   |
+|--------------------|--------------------------------------|-----------------------------------------|
+| Page               | Workspace                            | slug becomes workspace_id (or new UUID) |
+| Page.owner_uids    | Workspace.owner_uids + member_roles  | owners get role "organizer"             |
+| Page.member_uids   | member_roles[uid]="participant"      | explicit role                           |
+| Page.visibility    | Workspace.type                       | "public" -> "shared", "personal" stays  |
+| Page.timezone      | Workspace.timezone                   | direct copy, default "UTC"              |
+| Memory             | Occurrence (no Series parent)        | one-time, standalone occurrence         |
+| Memory.target      | Occurrence.scheduled_for             | date -> UTC datetime at midnight        |
+| Memory.title       | Occurrence.overrides.title           | stored in overrides                     |
+| Memory.place       | Occurrence.overrides.location        | direct copy                             |
+| Memory.time        | Occurrence.overrides.time            | direct copy                             |
+
+## New collections (this phase)
+
+- workspaces
+- series
+- occurrences
+- check_ins
+- notification_rules
+- delivery_logs
+
+## Preserved collections (unchanged)
+
+- pages
+- memories
+- users
+- audit_log
+
+## Migration Steps (manual, when ready)
+
+1. Backfill workspaces: for each doc in `pages`, call workspace_storage.create_workspace().
+2. Backfill occurrences: for each doc in `memories`, create a standalone Occurrence.
+3. Validate counts and spot-check a sample on both sides.
+4. Dual-read window: API v1 routes read from both old and new collections.
+5. Deprecate: archive old collections once API v2 is stable.
+
+## Backward Compatibility
+
+- src/page_storage.py and src/firestore_storage.py are unchanged.
+- All v1 API endpoints continue to work.
+- New modules (models.py, workspace_storage.py, series_storage.py) are additive only.
+- The React web app continues to use the v1 API until Phase 4.

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,451 @@
+"""Domain models for the pivot to a recurring-schedule platform.
+
+New vocabulary:
+- Workspace  (replaces Page)
+- Series     (a recurring schedule)
+- Occurrence (a single instance of a Series)
+- CheckIn    (participant attendance/confirmation)
+- NotificationRule  (per-workspace delivery preferences)
+- DeliveryLog       (immutable record of a sent notification)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Literal types
+# ---------------------------------------------------------------------------
+
+WorkspaceType = Literal["personal", "shared", "study"]
+SeriesKind = Literal["reminder", "meeting", "study_assignment"]
+SeriesStatus = Literal["active", "paused", "archived"]
+OccurrenceStatus = Literal["scheduled", "cancelled", "completed", "rescheduled"]
+CheckInStatus = Literal["pending", "confirmed", "declined", "missed"]
+MemberRole = Literal["organizer", "participant", "teacher", "assistant", "student"]
+NotificationChannel = Literal["email", "in_app", "telegram", "calendar"]
+DeliveryStatus = Literal["pending", "sent", "failed", "skipped"]
+
+
+# ---------------------------------------------------------------------------
+# Workspace
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Workspace:
+    """Top-level container for a group of related recurring schedules.
+
+    Maps to the Firestore ``workspaces`` collection.
+    """
+
+    workspace_id: str
+    title: str
+    type: WorkspaceType
+    timezone: str
+    owner_uids: list[str]
+    # uid -> MemberRole; owners are also listed here with role "organizer"
+    member_roles: dict[str, MemberRole] = field(default_factory=dict)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    description: str | None = None
+
+    def to_dict(self) -> dict:
+        now = _utcnow()
+        return {
+            "workspace_id": self.workspace_id,
+            "title": self.title,
+            "type": self.type,
+            "timezone": self.timezone,
+            "owner_uids": self.owner_uids,
+            "member_roles": self.member_roles,
+            "created_at": self.created_at or now,
+            "updated_at": self.updated_at or now,
+            "description": self.description,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Workspace:
+        return cls(
+            workspace_id=data["workspace_id"],
+            title=data["title"],
+            type=data["type"],
+            timezone=data.get("timezone", "UTC"),
+            owner_uids=list(data.get("owner_uids", [])),
+            member_roles=dict(data.get("member_roles", {})),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+            description=data.get("description"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Series
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ScheduleRule:
+    """Serializable recurrence rule.
+
+    ``frequency`` is one of:
+      - ``"daily"``     — every day
+      - ``"weekly"``    — every week on ``weekdays``
+      - ``"weekdays"``  — Monday–Friday
+      - ``"custom"``    — specific weekday list (same as weekly but explicit)
+      - ``"once"``      — no recurrence (single-shot)
+
+    ``weekdays`` is a list of ISO weekday integers (1=Monday … 7=Sunday).
+    For ``daily`` and ``weekdays`` frequency, ``weekdays`` is ignored.
+
+    ``interval`` is how many units to skip between occurrences (default 1).
+    For example ``interval=2`` with ``frequency="weekly"`` means every two weeks.
+
+    ``until`` is an optional UTC datetime after which no new occurrences
+    should be generated.
+
+    ``count`` is an optional cap on the total number of occurrences to generate.
+    """
+
+    frequency: Literal["daily", "weekly", "weekdays", "custom", "once"]
+    weekdays: list[int] = field(default_factory=list)  # 1=Mon … 7=Sun
+    interval: int = 1
+    until: datetime | None = None
+    count: int | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "frequency": self.frequency,
+            "weekdays": self.weekdays,
+            "interval": self.interval,
+            "until": self.until.isoformat() if self.until else None,
+            "count": self.count,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ScheduleRule:
+        until_raw = data.get("until")
+        return cls(
+            frequency=data["frequency"],
+            weekdays=list(data.get("weekdays", [])),
+            interval=int(data.get("interval", 1)),
+            until=datetime.fromisoformat(until_raw) if until_raw else None,
+            count=data.get("count"),
+        )
+
+
+@dataclass
+class Series:
+    """A recurring schedule owned by a Workspace.
+
+    Maps to the Firestore ``series`` collection.
+    """
+
+    series_id: str
+    workspace_id: str
+    kind: SeriesKind
+    title: str
+    schedule_rule: ScheduleRule
+    # Wall-clock time of day: "HH:MM" in the workspace's timezone
+    default_time: str | None = None
+    default_duration_minutes: int | None = None
+    default_location: str | None = None
+    default_online_link: str | None = None
+    status: SeriesStatus = "active"
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    description: str | None = None
+    # UID of the user who created this series
+    created_by: str | None = None
+
+    def to_dict(self) -> dict:
+        now = _utcnow()
+        return {
+            "series_id": self.series_id,
+            "workspace_id": self.workspace_id,
+            "kind": self.kind,
+            "title": self.title,
+            "schedule_rule": self.schedule_rule.to_dict(),
+            "default_time": self.default_time,
+            "default_duration_minutes": self.default_duration_minutes,
+            "default_location": self.default_location,
+            "default_online_link": self.default_online_link,
+            "status": self.status,
+            "created_at": self.created_at or now,
+            "updated_at": self.updated_at or now,
+            "description": self.description,
+            "created_by": self.created_by,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Series:
+        return cls(
+            series_id=data["series_id"],
+            workspace_id=data["workspace_id"],
+            kind=data["kind"],
+            title=data["title"],
+            schedule_rule=ScheduleRule.from_dict(data["schedule_rule"]),
+            default_time=data.get("default_time"),
+            default_duration_minutes=data.get("default_duration_minutes"),
+            default_location=data.get("default_location"),
+            default_online_link=data.get("default_online_link"),
+            status=data.get("status", "active"),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+            description=data.get("description"),
+            created_by=data.get("created_by"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Occurrence
+# ---------------------------------------------------------------------------
+
+@dataclass
+class OccurrenceOverrides:
+    """Fields that can be changed on a single occurrence without affecting the series."""
+
+    time: str | None = None
+    duration_minutes: int | None = None
+    location: str | None = None
+    online_link: str | None = None
+    title: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "time": self.time,
+            "duration_minutes": self.duration_minutes,
+            "location": self.location,
+            "online_link": self.online_link,
+            "title": self.title,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> OccurrenceOverrides:
+        return cls(
+            time=data.get("time"),
+            duration_minutes=data.get("duration_minutes"),
+            location=data.get("location"),
+            online_link=data.get("online_link"),
+            title=data.get("title"),
+        )
+
+
+@dataclass
+class Occurrence:
+    """A single scheduled instance of a Series.
+
+    Maps to the Firestore ``occurrences`` collection.
+    ``scheduled_for`` is an ISO 8601 UTC datetime string representing the
+    start of this occurrence.  Effective wall-clock time is determined by
+    either ``overrides.time`` or ``Series.default_time`` plus the workspace
+    timezone.
+    """
+
+    occurrence_id: str
+    series_id: str
+    workspace_id: str
+    # ISO 8601 UTC datetime, e.g. "2026-04-01T14:00:00+00:00"
+    scheduled_for: str
+    status: OccurrenceStatus = "scheduled"
+    overrides: OccurrenceOverrides | None = None
+    # Optional FK to a ContentPacket document (added in later phase)
+    content_packet_id: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    # Sequence index within the series (0-based), used for ordering
+    sequence_index: int | None = None
+
+    def to_dict(self) -> dict:
+        now = _utcnow()
+        return {
+            "occurrence_id": self.occurrence_id,
+            "series_id": self.series_id,
+            "workspace_id": self.workspace_id,
+            "scheduled_for": self.scheduled_for,
+            "status": self.status,
+            "overrides": self.overrides.to_dict() if self.overrides else None,
+            "content_packet_id": self.content_packet_id,
+            "created_at": self.created_at or now,
+            "updated_at": self.updated_at or now,
+            "sequence_index": self.sequence_index,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Occurrence:
+        raw_overrides = data.get("overrides")
+        return cls(
+            occurrence_id=data["occurrence_id"],
+            series_id=data["series_id"],
+            workspace_id=data["workspace_id"],
+            scheduled_for=data["scheduled_for"],
+            status=data.get("status", "scheduled"),
+            overrides=OccurrenceOverrides.from_dict(raw_overrides) if raw_overrides else None,
+            content_packet_id=data.get("content_packet_id"),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+            sequence_index=data.get("sequence_index"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# CheckIn
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CheckIn:
+    """Records a participant's attendance or response to an Occurrence.
+
+    Maps to the Firestore ``check_ins`` collection.
+    """
+
+    check_in_id: str
+    occurrence_id: str
+    series_id: str
+    workspace_id: str
+    user_id: str
+    status: CheckInStatus = "pending"
+    checked_in_at: datetime | None = None
+    note: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    def to_dict(self) -> dict:
+        now = _utcnow()
+        return {
+            "check_in_id": self.check_in_id,
+            "occurrence_id": self.occurrence_id,
+            "series_id": self.series_id,
+            "workspace_id": self.workspace_id,
+            "user_id": self.user_id,
+            "status": self.status,
+            "checked_in_at": self.checked_in_at,
+            "note": self.note,
+            "created_at": self.created_at or now,
+            "updated_at": self.updated_at or now,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> CheckIn:
+        return cls(
+            check_in_id=data["check_in_id"],
+            occurrence_id=data["occurrence_id"],
+            series_id=data["series_id"],
+            workspace_id=data["workspace_id"],
+            user_id=data["user_id"],
+            status=data.get("status", "pending"),
+            checked_in_at=data.get("checked_in_at"),
+            note=data.get("note"),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# NotificationRule
+# ---------------------------------------------------------------------------
+
+@dataclass
+class NotificationRule:
+    """Per-workspace rule controlling when and how notifications are sent.
+
+    Maps to the Firestore ``notification_rules`` collection.
+    """
+
+    rule_id: str
+    workspace_id: str
+    series_id: str | None  # None means workspace-level default
+    channel: NotificationChannel
+    # Minutes before the occurrence to send the reminder (e.g. 60 = 1 hour before)
+    remind_before_minutes: int
+    enabled: bool = True
+    # Optional: restrict delivery to specific member roles
+    target_roles: list[MemberRole] = field(default_factory=list)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    def to_dict(self) -> dict:
+        now = _utcnow()
+        return {
+            "rule_id": self.rule_id,
+            "workspace_id": self.workspace_id,
+            "series_id": self.series_id,
+            "channel": self.channel,
+            "remind_before_minutes": self.remind_before_minutes,
+            "enabled": self.enabled,
+            "target_roles": self.target_roles,
+            "created_at": self.created_at or now,
+            "updated_at": self.updated_at or now,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> NotificationRule:
+        return cls(
+            rule_id=data["rule_id"],
+            workspace_id=data["workspace_id"],
+            series_id=data.get("series_id"),
+            channel=data["channel"],
+            remind_before_minutes=int(data["remind_before_minutes"]),
+            enabled=bool(data.get("enabled", True)),
+            target_roles=list(data.get("target_roles", [])),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# DeliveryLog
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DeliveryLog:
+    """Immutable audit record for each notification delivery attempt.
+
+    Maps to the Firestore ``delivery_logs`` collection.
+    """
+
+    log_id: str
+    rule_id: str
+    occurrence_id: str
+    workspace_id: str
+    recipient_uid: str
+    channel: NotificationChannel
+    status: DeliveryStatus
+    sent_at: datetime | None = None
+    error: str | None = None
+    created_at: datetime | None = None
+
+    def to_dict(self) -> dict:
+        now = _utcnow()
+        return {
+            "log_id": self.log_id,
+            "rule_id": self.rule_id,
+            "occurrence_id": self.occurrence_id,
+            "workspace_id": self.workspace_id,
+            "recipient_uid": self.recipient_uid,
+            "channel": self.channel,
+            "status": self.status,
+            "sent_at": self.sent_at,
+            "error": self.error,
+            "created_at": self.created_at or now,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> DeliveryLog:
+        return cls(
+            log_id=data["log_id"],
+            rule_id=data["rule_id"],
+            occurrence_id=data["occurrence_id"],
+            workspace_id=data["workspace_id"],
+            recipient_uid=data["recipient_uid"],
+            channel=data["channel"],
+            status=data["status"],
+            sent_at=data.get("sent_at"),
+            error=data.get("error"),
+            created_at=data.get("created_at"),
+        )

--- a/src/series_storage.py
+++ b/src/series_storage.py
@@ -1,0 +1,286 @@
+"""Firestore-backed storage for Series, Occurrences, CheckIns, and delivery logs."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Sequence
+
+from firestore_storage import _get_client
+from models import CheckIn, DeliveryLog, NotificationRule, Occurrence, Series
+
+SERIES_COLLECTION = "series"
+OCCURRENCES_COLLECTION = "occurrences"
+CHECK_INS_COLLECTION = "check_ins"
+NOTIFICATION_RULES_COLLECTION = "notification_rules"
+DELIVERY_LOGS_COLLECTION = "delivery_logs"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Series CRUD
+# ---------------------------------------------------------------------------
+
+def create_series(series: Series) -> Series:
+    """Persist a new Series. series_id is used as the Firestore document ID."""
+    db = _get_client()
+    ref = db.collection(SERIES_COLLECTION).document(series.series_id)
+    if ref.get().exists:
+        raise ValueError(f"Series already exists: {series.series_id}")
+    now = _utcnow()
+    series.created_at = now
+    series.updated_at = now
+    ref.set(series.to_dict())
+    return series
+
+
+def get_series(series_id: str) -> Series | None:
+    """Fetch a Series by ID. Returns None if not found."""
+    db = _get_client()
+    doc = db.collection(SERIES_COLLECTION).document(series_id).get()
+    if not doc.exists:
+        return None
+    return Series.from_dict(doc.to_dict())
+
+
+def update_series(series_id: str, updates: dict) -> Series:
+    """Apply partial updates to a Series. Raises if not found."""
+    db = _get_client()
+    ref = db.collection(SERIES_COLLECTION).document(series_id)
+    doc = ref.get()
+    if not doc.exists:
+        raise ValueError(f"Series not found: {series_id}")
+    updates["updated_at"] = _utcnow()
+    ref.update(updates)
+    return Series.from_dict({**doc.to_dict(), **updates})
+
+
+def delete_series(series_id: str) -> None:
+    """Hard-delete a Series document."""
+    db = _get_client()
+    db.collection(SERIES_COLLECTION).document(series_id).delete()
+
+
+def list_series_for_workspace(workspace_id: str) -> list[Series]:
+    """Return all Series belonging to workspace_id, ordered by created_at."""
+    db = _get_client()
+    docs = (
+        db.collection(SERIES_COLLECTION)
+        .where("workspace_id", "==", workspace_id)
+        .stream()
+    )
+    results = [Series.from_dict(doc.to_dict()) for doc in docs]
+    results.sort(key=lambda s: s.created_at or datetime.min.replace(tzinfo=timezone.utc))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Occurrence CRUD
+# ---------------------------------------------------------------------------
+
+def save_occurrence(occurrence: Occurrence) -> Occurrence:
+    """Upsert an Occurrence. occurrence_id is the Firestore document ID."""
+    db = _get_client()
+    now = _utcnow()
+    if occurrence.created_at is None:
+        occurrence.created_at = now
+    occurrence.updated_at = now
+    db.collection(OCCURRENCES_COLLECTION).document(occurrence.occurrence_id).set(
+        occurrence.to_dict()
+    )
+    return occurrence
+
+
+def get_occurrence(occurrence_id: str) -> Occurrence | None:
+    """Fetch an Occurrence by ID. Returns None if not found."""
+    db = _get_client()
+    doc = db.collection(OCCURRENCES_COLLECTION).document(occurrence_id).get()
+    if not doc.exists:
+        return None
+    return Occurrence.from_dict(doc.to_dict())
+
+
+def update_occurrence(occurrence_id: str, updates: dict) -> Occurrence:
+    """Apply partial updates to an Occurrence. Raises if not found."""
+    db = _get_client()
+    ref = db.collection(OCCURRENCES_COLLECTION).document(occurrence_id)
+    doc = ref.get()
+    if not doc.exists:
+        raise ValueError(f"Occurrence not found: {occurrence_id}")
+    updates["updated_at"] = _utcnow()
+    ref.update(updates)
+    return Occurrence.from_dict({**doc.to_dict(), **updates})
+
+
+def delete_occurrence(occurrence_id: str) -> None:
+    """Hard-delete an Occurrence document."""
+    db = _get_client()
+    db.collection(OCCURRENCES_COLLECTION).document(occurrence_id).delete()
+
+
+def list_occurrences_for_series(
+    series_id: str,
+    status: str | None = None,
+) -> list[Occurrence]:
+    """Return Occurrences for a Series, optionally filtered by status."""
+    db = _get_client()
+    query = db.collection(OCCURRENCES_COLLECTION).where("series_id", "==", series_id)
+    if status is not None:
+        query = query.where("status", "==", status)
+    docs = query.stream()
+    results = [Occurrence.from_dict(doc.to_dict()) for doc in docs]
+    results.sort(key=lambda o: o.scheduled_for)
+    return results
+
+
+def list_occurrences_for_workspace(
+    workspace_id: str,
+    status: str | None = None,
+) -> list[Occurrence]:
+    """Return Occurrences for a workspace, optionally filtered by status."""
+    db = _get_client()
+    query = (
+        db.collection(OCCURRENCES_COLLECTION)
+        .where("workspace_id", "==", workspace_id)
+    )
+    if status is not None:
+        query = query.where("status", "==", status)
+    docs = query.stream()
+    results = [Occurrence.from_dict(doc.to_dict()) for doc in docs]
+    results.sort(key=lambda o: o.scheduled_for)
+    return results
+
+
+def save_occurrences_batch(occurrences: Sequence[Occurrence]) -> None:
+    """Batch-write a list of Occurrences in a single Firestore transaction."""
+    if not occurrences:
+        return
+    db = _get_client()
+    batch = db.batch()
+    now = _utcnow()
+    for occ in occurrences:
+        if occ.created_at is None:
+            occ.created_at = now
+        occ.updated_at = now
+        ref = db.collection(OCCURRENCES_COLLECTION).document(occ.occurrence_id)
+        batch.set(ref, occ.to_dict())
+    batch.commit()
+
+
+# ---------------------------------------------------------------------------
+# CheckIn CRUD
+# ---------------------------------------------------------------------------
+
+def save_check_in(check_in: CheckIn) -> CheckIn:
+    """Upsert a CheckIn."""
+    db = _get_client()
+    now = _utcnow()
+    if check_in.created_at is None:
+        check_in.created_at = now
+    check_in.updated_at = now
+    db.collection(CHECK_INS_COLLECTION).document(check_in.check_in_id).set(
+        check_in.to_dict()
+    )
+    return check_in
+
+
+def get_check_in(check_in_id: str) -> CheckIn | None:
+    """Fetch a CheckIn by ID. Returns None if not found."""
+    db = _get_client()
+    doc = db.collection(CHECK_INS_COLLECTION).document(check_in_id).get()
+    if not doc.exists:
+        return None
+    return CheckIn.from_dict(doc.to_dict())
+
+
+def list_check_ins_for_occurrence(occurrence_id: str) -> list[CheckIn]:
+    """Return all CheckIns for a specific Occurrence."""
+    db = _get_client()
+    docs = (
+        db.collection(CHECK_INS_COLLECTION)
+        .where("occurrence_id", "==", occurrence_id)
+        .stream()
+    )
+    return [CheckIn.from_dict(doc.to_dict()) for doc in docs]
+
+
+def get_check_in_for_user(occurrence_id: str, user_id: str) -> CheckIn | None:
+    """Return the CheckIn for a specific user on a specific Occurrence, or None."""
+    db = _get_client()
+    docs = (
+        db.collection(CHECK_INS_COLLECTION)
+        .where("occurrence_id", "==", occurrence_id)
+        .where("user_id", "==", user_id)
+        .limit(1)
+        .stream()
+    )
+    for doc in docs:
+        return CheckIn.from_dict(doc.to_dict())
+    return None
+
+
+# ---------------------------------------------------------------------------
+# NotificationRule CRUD
+# ---------------------------------------------------------------------------
+
+def save_notification_rule(rule: NotificationRule) -> NotificationRule:
+    """Upsert a NotificationRule."""
+    db = _get_client()
+    now = _utcnow()
+    if rule.created_at is None:
+        rule.created_at = now
+    rule.updated_at = now
+    db.collection(NOTIFICATION_RULES_COLLECTION).document(rule.rule_id).set(
+        rule.to_dict()
+    )
+    return rule
+
+
+def get_notification_rule(rule_id: str) -> NotificationRule | None:
+    """Fetch a NotificationRule by ID."""
+    db = _get_client()
+    doc = db.collection(NOTIFICATION_RULES_COLLECTION).document(rule_id).get()
+    if not doc.exists:
+        return None
+    return NotificationRule.from_dict(doc.to_dict())
+
+
+def list_notification_rules_for_workspace(workspace_id: str) -> list[NotificationRule]:
+    """Return all enabled NotificationRules for a workspace."""
+    db = _get_client()
+    docs = (
+        db.collection(NOTIFICATION_RULES_COLLECTION)
+        .where("workspace_id", "==", workspace_id)
+        .stream()
+    )
+    return [NotificationRule.from_dict(doc.to_dict()) for doc in docs]
+
+
+# ---------------------------------------------------------------------------
+# DeliveryLog (append-only)
+# ---------------------------------------------------------------------------
+
+def append_delivery_log(log: DeliveryLog) -> DeliveryLog:
+    """Write an immutable DeliveryLog entry."""
+    db = _get_client()
+    now = _utcnow()
+    if log.created_at is None:
+        log.created_at = now
+    db.collection(DELIVERY_LOGS_COLLECTION).document(log.log_id).set(log.to_dict())
+    return log
+
+
+def list_delivery_logs_for_occurrence(occurrence_id: str) -> list[DeliveryLog]:
+    """Return all delivery log entries for a specific Occurrence."""
+    db = _get_client()
+    docs = (
+        db.collection(DELIVERY_LOGS_COLLECTION)
+        .where("occurrence_id", "==", occurrence_id)
+        .stream()
+    )
+    results = [DeliveryLog.from_dict(doc.to_dict()) for doc in docs]
+    results.sort(key=lambda d: d.created_at or datetime.min.replace(tzinfo=timezone.utc))
+    return results

--- a/src/workspace_storage.py
+++ b/src/workspace_storage.py
@@ -1,0 +1,193 @@
+"""Firestore-backed storage for Workspaces and workspace membership."""
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from firestore_storage import _get_client
+from models import MemberRole, Workspace
+
+WORKSPACES_COLLECTION = "workspaces"
+WORKSPACE_INVITES_SUBCOLLECTION = "workspace_invites"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def create_workspace(workspace: Workspace) -> Workspace:
+    """Persist a new Workspace document. workspace_id is used as doc ID."""
+    if not workspace.owner_uids:
+        raise ValueError("Workspace must have at least one owner")
+    db = _get_client()
+    ref = db.collection(WORKSPACES_COLLECTION).document(workspace.workspace_id)
+    if ref.get().exists:
+        raise ValueError(f"Workspace already exists: {workspace.workspace_id}")
+    now = _utcnow()
+    workspace.created_at = now
+    workspace.updated_at = now
+    for uid in workspace.owner_uids:
+        workspace.member_roles.setdefault(uid, "organizer")
+    ref.set(workspace.to_dict())
+    return workspace
+
+
+def get_workspace(workspace_id: str) -> Workspace | None:
+    """Fetch a Workspace by its ID. Returns None if not found."""
+    db = _get_client()
+    doc = db.collection(WORKSPACES_COLLECTION).document(workspace_id).get()
+    if not doc.exists:
+        return None
+    return Workspace.from_dict(doc.to_dict())
+
+
+def update_workspace(workspace_id: str, updates: dict) -> Workspace:
+    """Apply a partial update to a Workspace. Raises if not found."""
+    db = _get_client()
+    ref = db.collection(WORKSPACES_COLLECTION).document(workspace_id)
+    doc = ref.get()
+    if not doc.exists:
+        raise ValueError(f"Workspace not found: {workspace_id}")
+    updates["updated_at"] = _utcnow()
+    ref.update(updates)
+    return Workspace.from_dict({**doc.to_dict(), **updates})
+
+
+def delete_workspace(workspace_id: str) -> None:
+    """Hard-delete a Workspace document. Does not cascade to sub-collections."""
+    db = _get_client()
+    db.collection(WORKSPACES_COLLECTION).document(workspace_id).delete()
+
+
+def list_workspaces_for_user(uid: str) -> list[Workspace]:
+    """Return all Workspaces where uid is listed as an owner."""
+    db = _get_client()
+    docs = (
+        db.collection(WORKSPACES_COLLECTION)
+        .where("owner_uids", "array_contains", uid)
+        .stream()
+    )
+    return [Workspace.from_dict(doc.to_dict()) for doc in docs]
+
+
+def add_member(workspace_id: str, uid: str, role: MemberRole) -> Workspace:
+    """Add or update uid role in workspace_id."""
+    from google.cloud.firestore import ArrayUnion
+    db = _get_client()
+    ref = db.collection(WORKSPACES_COLLECTION).document(workspace_id)
+    if not ref.get().exists:
+        raise ValueError(f"Workspace not found: {workspace_id}")
+    updates: dict = {
+        f"member_roles.{uid}": role,
+        "updated_at": _utcnow(),
+    }
+    if role == "organizer":
+        updates["owner_uids"] = ArrayUnion([uid])
+    ref.update(updates)
+    return get_workspace(workspace_id)  # type: ignore[return-value]
+
+
+def remove_member(workspace_id: str, uid: str) -> Workspace:
+    """Remove uid from workspace_id. Raises if would leave no organizers."""
+    from google.cloud.firestore import ArrayRemove
+    from google.cloud.firestore_v1 import DELETE_FIELD
+    workspace = get_workspace(workspace_id)
+    if workspace is None:
+        raise ValueError(f"Workspace not found: {workspace_id}")
+    current_role = workspace.member_roles.get(uid)
+    if current_role is None:
+        raise ValueError(f"User {uid!r} is not a member of {workspace_id!r}")
+    if current_role == "organizer":
+        organizer_count = sum(1 for r in workspace.member_roles.values() if r == "organizer")
+        if organizer_count <= 1:
+            raise ValueError("Cannot remove the last organizer of a workspace")
+    db = _get_client()
+    ref = db.collection(WORKSPACES_COLLECTION).document(workspace_id)
+    updates: dict = {
+        f"member_roles.{uid}": DELETE_FIELD,
+        "updated_at": _utcnow(),
+    }
+    if current_role == "organizer":
+        updates["owner_uids"] = ArrayRemove([uid])
+    ref.update(updates)
+    return get_workspace(workspace_id)  # type: ignore[return-value]
+
+
+def get_member_role(workspace_id: str, uid: str) -> MemberRole | None:
+    """Return uid role in workspace_id, or None if not a member."""
+    workspace = get_workspace(workspace_id)
+    if workspace is None:
+        return None
+    return workspace.member_roles.get(uid)  # type: ignore[return-value]
+
+
+def create_workspace_invite(
+    workspace_id: str,
+    created_by: str,
+    role: MemberRole = "participant",
+    expires_in_days: int = 7,
+) -> dict:
+    """Generate a shareable invite for a workspace."""
+    valid_roles = ("organizer", "participant", "teacher", "assistant", "student")
+    if role not in valid_roles:
+        raise ValueError(f"Invalid role: {role!r}")
+    invite_id = secrets.token_urlsafe(16)
+    now = _utcnow()
+    invite_doc = {
+        "invite_id": invite_id,
+        "workspace_id": workspace_id,
+        "created_by": created_by,
+        "created_at": now,
+        "expires_at": now + timedelta(days=expires_in_days),
+        "accepted_by": None,
+        "role": role,
+    }
+    db = _get_client()
+    (db.collection(WORKSPACES_COLLECTION)
+     .document(workspace_id)
+     .collection(WORKSPACE_INVITES_SUBCOLLECTION)
+     .document(invite_id)
+     .set(invite_doc))
+    return invite_doc
+
+
+def find_workspace_invite(invite_id: str) -> dict | None:
+    """Find a workspace invite by ID (collection group query)."""
+    db = _get_client()
+    docs = (
+        db.collection_group(WORKSPACE_INVITES_SUBCOLLECTION)
+        .where("invite_id", "==", invite_id)
+        .limit(1)
+        .stream()
+    )
+    for doc in docs:
+        return doc.to_dict()
+    return None
+
+
+def accept_workspace_invite(invite_id: str, accepting_uid: str) -> dict:
+    """Accept a workspace invite: add user and mark invite consumed."""
+    invite = find_workspace_invite(invite_id)
+    if invite is None:
+        raise ValueError("Invite not found")
+    if invite.get("accepted_by") is not None:
+        raise ValueError("Invite has already been accepted")
+    now = _utcnow()
+    expires_at = invite.get("expires_at")
+    if expires_at:
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at < now:
+            raise ValueError("Invite has expired")
+    workspace_id = invite["workspace_id"]
+    role: MemberRole = invite.get("role", "participant")
+    add_member(workspace_id, accepting_uid, role)
+    db = _get_client()
+    (db.collection(WORKSPACES_COLLECTION)
+     .document(workspace_id)
+     .collection(WORKSPACE_INVITES_SUBCOLLECTION)
+     .document(invite_id)
+     .update({"accepted_by": accepting_uid}))
+    invite["accepted_by"] = accepting_uid
+    return invite

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,309 @@
+"""Tests for Phase 1 domain models (models.py).
+
+These tests exercise serialization round-trips and validation logic
+without requiring a Firestore connection.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from models import (
+    CheckIn,
+    DeliveryLog,
+    NotificationRule,
+    Occurrence,
+    OccurrenceOverrides,
+    ScheduleRule,
+    Series,
+    Workspace,
+)
+
+
+# ---------------------------------------------------------------------------
+# ScheduleRule
+# ---------------------------------------------------------------------------
+
+class TestScheduleRule:
+    def test_roundtrip_weekly(self):
+        rule = ScheduleRule(frequency="weekly", weekdays=[1, 3, 5], interval=2)
+        restored = ScheduleRule.from_dict(rule.to_dict())
+        assert restored.frequency == "weekly"
+        assert restored.weekdays == [1, 3, 5]
+        assert restored.interval == 2
+        assert restored.until is None
+        assert restored.count is None
+
+    def test_roundtrip_with_until(self):
+        until = datetime(2026, 12, 31, 23, 59, 0, tzinfo=timezone.utc)
+        rule = ScheduleRule(frequency="daily", until=until)
+        restored = ScheduleRule.from_dict(rule.to_dict())
+        assert restored.until is not None
+        assert restored.until.year == 2026
+
+    def test_roundtrip_once(self):
+        rule = ScheduleRule(frequency="once")
+        restored = ScheduleRule.from_dict(rule.to_dict())
+        assert restored.frequency == "once"
+        assert restored.weekdays == []
+
+    def test_default_interval(self):
+        rule = ScheduleRule(frequency="daily")
+        assert rule.interval == 1
+        restored = ScheduleRule.from_dict(rule.to_dict())
+        assert restored.interval == 1
+
+
+# ---------------------------------------------------------------------------
+# Workspace
+# ---------------------------------------------------------------------------
+
+class TestWorkspace:
+    def _make(self, **kwargs) -> Workspace:
+        defaults = dict(
+            workspace_id="ws-1",
+            title="Team Standups",
+            type="shared",
+            timezone="America/New_York",
+            owner_uids=["uid-alice"],
+        )
+        defaults.update(kwargs)
+        return Workspace(**defaults)
+
+    def test_roundtrip(self):
+        ws = self._make()
+        restored = Workspace.from_dict(ws.to_dict())
+        assert restored.workspace_id == "ws-1"
+        assert restored.title == "Team Standups"
+        assert restored.type == "shared"
+        assert restored.timezone == "America/New_York"
+        assert restored.owner_uids == ["uid-alice"]
+
+    def test_member_roles_roundtrip(self):
+        ws = self._make(member_roles={"uid-alice": "organizer", "uid-bob": "participant"})
+        restored = Workspace.from_dict(ws.to_dict())
+        assert restored.member_roles["uid-alice"] == "organizer"
+        assert restored.member_roles["uid-bob"] == "participant"
+
+    def test_default_timezone(self):
+        ws = self._make()
+        d = ws.to_dict()
+        del d["timezone"]
+        # Simulate loading a doc without timezone
+        restored = Workspace.from_dict({**d, "workspace_id": "ws-1"})
+        assert restored.timezone == "UTC"
+
+    def test_description_optional(self):
+        ws = self._make()
+        assert ws.description is None
+        restored = Workspace.from_dict(ws.to_dict())
+        assert restored.description is None
+
+
+# ---------------------------------------------------------------------------
+# Series
+# ---------------------------------------------------------------------------
+
+class TestSeries:
+    def _make(self, **kwargs) -> Series:
+        defaults = dict(
+            series_id="series-1",
+            workspace_id="ws-1",
+            kind="meeting",
+            title="Weekly Standup",
+            schedule_rule=ScheduleRule(frequency="weekly", weekdays=[1]),
+            default_time="09:00",
+            created_by="uid-alice",
+        )
+        defaults.update(kwargs)
+        return Series(**defaults)
+
+    def test_roundtrip(self):
+        s = self._make()
+        restored = Series.from_dict(s.to_dict())
+        assert restored.series_id == "series-1"
+        assert restored.kind == "meeting"
+        assert restored.schedule_rule.frequency == "weekly"
+        assert restored.schedule_rule.weekdays == [1]
+        assert restored.default_time == "09:00"
+        assert restored.status == "active"
+
+    def test_optional_fields(self):
+        s = self._make()
+        assert s.default_location is None
+        assert s.default_online_link is None
+        assert s.default_duration_minutes is None
+        restored = Series.from_dict(s.to_dict())
+        assert restored.default_location is None
+
+    def test_status_default(self):
+        s = self._make()
+        d = s.to_dict()
+        del d["status"]
+        restored = Series.from_dict(d)
+        assert restored.status == "active"
+
+
+# ---------------------------------------------------------------------------
+# Occurrence
+# ---------------------------------------------------------------------------
+
+class TestOccurrence:
+    def _make(self, **kwargs) -> Occurrence:
+        defaults = dict(
+            occurrence_id="occ-1",
+            series_id="series-1",
+            workspace_id="ws-1",
+            scheduled_for="2026-04-01T14:00:00+00:00",
+        )
+        defaults.update(kwargs)
+        return Occurrence(**defaults)
+
+    def test_roundtrip(self):
+        occ = self._make()
+        restored = Occurrence.from_dict(occ.to_dict())
+        assert restored.occurrence_id == "occ-1"
+        assert restored.scheduled_for == "2026-04-01T14:00:00+00:00"
+        assert restored.status == "scheduled"
+        assert restored.overrides is None
+
+    def test_with_overrides(self):
+        overrides = OccurrenceOverrides(
+            time="10:00",
+            location="Room B",
+            online_link="https://zoom.us/j/123",
+        )
+        occ = self._make(overrides=overrides)
+        restored = Occurrence.from_dict(occ.to_dict())
+        assert restored.overrides is not None
+        assert restored.overrides.time == "10:00"
+        assert restored.overrides.location == "Room B"
+        assert restored.overrides.online_link == "https://zoom.us/j/123"
+
+    def test_status_values(self):
+        for status in ("scheduled", "cancelled", "completed", "rescheduled"):
+            occ = self._make(status=status)
+            restored = Occurrence.from_dict(occ.to_dict())
+            assert restored.status == status
+
+    def test_status_default(self):
+        occ = self._make()
+        d = occ.to_dict()
+        del d["status"]
+        restored = Occurrence.from_dict(d)
+        assert restored.status == "scheduled"
+
+    def test_sequence_index(self):
+        occ = self._make(sequence_index=5)
+        restored = Occurrence.from_dict(occ.to_dict())
+        assert restored.sequence_index == 5
+
+
+# ---------------------------------------------------------------------------
+# CheckIn
+# ---------------------------------------------------------------------------
+
+class TestCheckIn:
+    def _make(self, **kwargs) -> CheckIn:
+        defaults = dict(
+            check_in_id="ci-1",
+            occurrence_id="occ-1",
+            series_id="series-1",
+            workspace_id="ws-1",
+            user_id="uid-bob",
+        )
+        defaults.update(kwargs)
+        return CheckIn(**defaults)
+
+    def test_roundtrip(self):
+        ci = self._make()
+        restored = CheckIn.from_dict(ci.to_dict())
+        assert restored.check_in_id == "ci-1"
+        assert restored.user_id == "uid-bob"
+        assert restored.status == "pending"
+
+    def test_confirmed_with_timestamp(self):
+        now = datetime(2026, 4, 1, 14, 5, 0, tzinfo=timezone.utc)
+        ci = self._make(status="confirmed", checked_in_at=now)
+        restored = CheckIn.from_dict(ci.to_dict())
+        assert restored.status == "confirmed"
+        assert restored.checked_in_at == now
+
+    def test_note_optional(self):
+        ci = self._make(note="Running 5 min late")
+        restored = CheckIn.from_dict(ci.to_dict())
+        assert restored.note == "Running 5 min late"
+
+
+# ---------------------------------------------------------------------------
+# NotificationRule
+# ---------------------------------------------------------------------------
+
+class TestNotificationRule:
+    def test_roundtrip(self):
+        rule = NotificationRule(
+            rule_id="rule-1",
+            workspace_id="ws-1",
+            series_id="series-1",
+            channel="email",
+            remind_before_minutes=60,
+            target_roles=["participant", "organizer"],
+        )
+        restored = NotificationRule.from_dict(rule.to_dict())
+        assert restored.rule_id == "rule-1"
+        assert restored.channel == "email"
+        assert restored.remind_before_minutes == 60
+        assert restored.target_roles == ["participant", "organizer"]
+        assert restored.enabled is True
+
+    def test_workspace_level_rule(self):
+        rule = NotificationRule(
+            rule_id="rule-2",
+            workspace_id="ws-1",
+            series_id=None,
+            channel="in_app",
+            remind_before_minutes=30,
+        )
+        restored = NotificationRule.from_dict(rule.to_dict())
+        assert restored.series_id is None
+
+
+# ---------------------------------------------------------------------------
+# DeliveryLog
+# ---------------------------------------------------------------------------
+
+class TestDeliveryLog:
+    def test_roundtrip_sent(self):
+        sent_at = datetime(2026, 4, 1, 13, 0, 0, tzinfo=timezone.utc)
+        log = DeliveryLog(
+            log_id="log-1",
+            rule_id="rule-1",
+            occurrence_id="occ-1",
+            workspace_id="ws-1",
+            recipient_uid="uid-bob",
+            channel="email",
+            status="sent",
+            sent_at=sent_at,
+        )
+        restored = DeliveryLog.from_dict(log.to_dict())
+        assert restored.log_id == "log-1"
+        assert restored.status == "sent"
+        assert restored.sent_at == sent_at
+        assert restored.error is None
+
+    def test_roundtrip_failed(self):
+        log = DeliveryLog(
+            log_id="log-2",
+            rule_id="rule-1",
+            occurrence_id="occ-1",
+            workspace_id="ws-1",
+            recipient_uid="uid-bob",
+            channel="email",
+            status="failed",
+            error="SMTP connection refused",
+        )
+        restored = DeliveryLog.from_dict(log.to_dict())
+        assert restored.status == "failed"
+        assert restored.error == "SMTP connection refused"

--- a/tests/test_workspace_storage.py
+++ b/tests/test_workspace_storage.py
@@ -1,0 +1,289 @@
+"""Tests for workspace_storage.py using mocked Firestore."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+import workspace_storage
+from models import Workspace
+from workspace_storage import (
+    WORKSPACES_COLLECTION,
+    WORKSPACE_INVITES_SUBCOLLECTION,
+    accept_workspace_invite,
+    add_member,
+    create_workspace,
+    create_workspace_invite,
+    delete_workspace,
+    find_workspace_invite,
+    get_member_role,
+    get_workspace,
+    list_workspaces_for_user,
+    remove_member,
+    update_workspace,
+)
+
+
+def _utcnow():
+    return datetime.now(timezone.utc)
+
+
+def _mock_doc(exists=True, data=None, doc_id="ws-1"):
+    doc = MagicMock()
+    doc.exists = exists
+    doc.id = doc_id
+    if data:
+        doc.to_dict.return_value = data
+    return doc
+
+
+def _ws_data(**kwargs):
+    defaults = {
+        "workspace_id": "ws-1",
+        "title": "Team Standups",
+        "type": "shared",
+        "timezone": "UTC",
+        "owner_uids": ["uid-alice"],
+        "member_roles": {"uid-alice": "organizer"},
+        "description": None,
+        "created_at": _utcnow(),
+        "updated_at": _utcnow(),
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+# ---------------------------------------------------------------------------
+# create_workspace
+# ---------------------------------------------------------------------------
+
+class TestCreateWorkspace:
+    def test_creates_document(self):
+        ws = Workspace(
+            workspace_id="ws-1",
+            title="Standups",
+            type="shared",
+            timezone="UTC",
+            owner_uids=["uid-alice"],
+        )
+        mock_db = MagicMock()
+        mock_ref = MagicMock()
+        mock_ref.get.return_value = _mock_doc(exists=False)
+        mock_db.collection.return_value.document.return_value = mock_ref
+
+        with patch("workspace_storage._get_client", return_value=mock_db):
+            result = create_workspace(ws)
+
+        mock_ref.set.assert_called_once()
+        assert result.workspace_id == "ws-1"
+        assert result.created_at is not None
+
+    def test_owner_added_to_member_roles(self):
+        ws = Workspace(
+            workspace_id="ws-1",
+            title="Standups",
+            type="shared",
+            timezone="UTC",
+            owner_uids=["uid-alice"],
+            member_roles={},
+        )
+        mock_db = MagicMock()
+        mock_ref = MagicMock()
+        mock_ref.get.return_value = _mock_doc(exists=False)
+        mock_db.collection.return_value.document.return_value = mock_ref
+
+        with patch("workspace_storage._get_client", return_value=mock_db):
+            result = create_workspace(ws)
+
+        assert result.member_roles.get("uid-alice") == "organizer"
+
+    def test_raises_if_no_owners(self):
+        ws = Workspace(
+            workspace_id="ws-1",
+            title="Standups",
+            type="shared",
+            timezone="UTC",
+            owner_uids=[],
+        )
+        with pytest.raises(ValueError, match="must have at least one owner"):
+            create_workspace(ws)
+
+    def test_raises_if_already_exists(self):
+        ws = Workspace(
+            workspace_id="ws-1",
+            title="Standups",
+            type="shared",
+            timezone="UTC",
+            owner_uids=["uid-alice"],
+        )
+        mock_db = MagicMock()
+        mock_ref = MagicMock()
+        mock_ref.get.return_value = _mock_doc(exists=True)
+        mock_db.collection.return_value.document.return_value = mock_ref
+
+        with patch("workspace_storage._get_client", return_value=mock_db):
+            with pytest.raises(ValueError, match="already exists"):
+                create_workspace(ws)
+
+
+# ---------------------------------------------------------------------------
+# get_workspace
+# ---------------------------------------------------------------------------
+
+class TestGetWorkspace:
+    def test_returns_workspace(self):
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.get.return_value = (
+            _mock_doc(data=_ws_data())
+        )
+        with patch("workspace_storage._get_client", return_value=mock_db):
+            ws = get_workspace("ws-1")
+        assert ws is not None
+        assert ws.workspace_id == "ws-1"
+        assert ws.title == "Team Standups"
+
+    def test_returns_none_if_missing(self):
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.get.return_value = (
+            _mock_doc(exists=False)
+        )
+        with patch("workspace_storage._get_client", return_value=mock_db):
+            ws = get_workspace("no-such-id")
+        assert ws is None
+
+
+# ---------------------------------------------------------------------------
+# update_workspace
+# ---------------------------------------------------------------------------
+
+class TestUpdateWorkspace:
+    def test_updates_fields(self):
+        mock_db = MagicMock()
+        mock_ref = MagicMock()
+        mock_ref.get.return_value = _mock_doc(data=_ws_data())
+        mock_db.collection.return_value.document.return_value = mock_ref
+
+        with patch("workspace_storage._get_client", return_value=mock_db):
+            ws = update_workspace("ws-1", {"title": "New Title"})
+
+        mock_ref.update.assert_called_once()
+        update_args = mock_ref.update.call_args[0][0]
+        assert update_args["title"] == "New Title"
+        assert "updated_at" in update_args
+
+    def test_raises_if_not_found(self):
+        mock_db = MagicMock()
+        mock_ref = MagicMock()
+        mock_ref.get.return_value = _mock_doc(exists=False)
+        mock_db.collection.return_value.document.return_value = mock_ref
+
+        with patch("workspace_storage._get_client", return_value=mock_db):
+            with pytest.raises(ValueError, match="not found"):
+                update_workspace("ws-missing", {"title": "x"})
+
+
+# ---------------------------------------------------------------------------
+# add_member / remove_member / get_member_role
+# ---------------------------------------------------------------------------
+
+class TestMemberManagement:
+    def test_add_participant(self):
+        mock_db = MagicMock()
+        mock_ref = MagicMock()
+        mock_ref.get.return_value = _mock_doc(data=_ws_data())
+        mock_db.collection.return_value.document.return_value = mock_ref
+
+        # get_workspace is called again after update; return updated data
+        data_after = _ws_data(member_roles={"uid-alice": "organizer", "uid-bob": "participant"})
+        mock_doc_after = _mock_doc(data=data_after)
+        # First call: exists check inside add_member; second: get_workspace return
+        mock_ref.get.side_effect = [_mock_doc(data=_ws_data()), mock_doc_after]
+
+        with patch("workspace_storage._get_client", return_value=mock_db):
+            with patch("workspace_storage.get_workspace") as mock_get:
+                mock_get.return_value = Workspace.from_dict(data_after)
+                result = add_member("ws-1", "uid-bob", "participant")
+
+        mock_ref.update.assert_called_once()
+        update_args = mock_ref.update.call_args[0][0]
+        assert "member_roles.uid-bob" in update_args
+        assert update_args["member_roles.uid-bob"] == "participant"
+
+    def test_get_member_role_returns_none_for_nonmember(self):
+        data = _ws_data(member_roles={"uid-alice": "organizer"})
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.get.return_value = (
+            _mock_doc(data=data)
+        )
+        with patch("workspace_storage._get_client", return_value=mock_db):
+            role = get_member_role("ws-1", "uid-unknown")
+        assert role is None
+
+    def test_remove_last_organizer_raises(self):
+        data = _ws_data(member_roles={"uid-alice": "organizer"})
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.get.return_value = (
+            _mock_doc(data=data)
+        )
+        with patch("workspace_storage._get_client", return_value=mock_db):
+            with patch("workspace_storage.get_workspace") as mock_get:
+                mock_get.return_value = Workspace.from_dict(data)
+                with pytest.raises(ValueError, match="last organizer"):
+                    remove_member("ws-1", "uid-alice")
+
+
+# ---------------------------------------------------------------------------
+# create_workspace_invite / find / accept
+# ---------------------------------------------------------------------------
+
+class TestWorkspaceInvites:
+    def test_create_invite_returns_dict(self):
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.collection.return_value.document.return_value.set.return_value = None
+
+        with patch("workspace_storage._get_client", return_value=mock_db):
+            invite = create_workspace_invite("ws-1", "uid-alice", role="participant")
+
+        assert "invite_id" in invite
+        assert invite["workspace_id"] == "ws-1"
+        assert invite["role"] == "participant"
+        assert invite["accepted_by"] is None
+
+    def test_invalid_role_raises(self):
+        with pytest.raises(ValueError, match="Invalid role"):
+            create_workspace_invite("ws-1", "uid-alice", role="superadmin")
+
+    def test_accept_already_accepted_raises(self):
+        invite_data = {
+            "invite_id": "inv-1",
+            "workspace_id": "ws-1",
+            "created_by": "uid-alice",
+            "created_at": _utcnow(),
+            "expires_at": _utcnow() + timedelta(days=7),
+            "accepted_by": "uid-charlie",  # already accepted
+            "role": "participant",
+        }
+        with patch("workspace_storage.find_workspace_invite", return_value=invite_data):
+            with pytest.raises(ValueError, match="already been accepted"):
+                accept_workspace_invite("inv-1", "uid-bob")
+
+    def test_accept_expired_raises(self):
+        invite_data = {
+            "invite_id": "inv-1",
+            "workspace_id": "ws-1",
+            "created_by": "uid-alice",
+            "created_at": _utcnow() - timedelta(days=10),
+            "expires_at": _utcnow() - timedelta(days=3),  # expired
+            "accepted_by": None,
+            "role": "participant",
+        }
+        with patch("workspace_storage.find_workspace_invite", return_value=invite_data):
+            with pytest.raises(ValueError, match="expired"):
+                accept_workspace_invite("inv-1", "uid-bob")
+
+    def test_accept_not_found_raises(self):
+        with patch("workspace_storage.find_workspace_invite", return_value=None):
+            with pytest.raises(ValueError, match="not found"):
+                accept_workspace_invite("inv-missing", "uid-bob")


### PR DESCRIPTION
## Phase 1: Data Model Redesign

Introduces the foundational domain model for the pivot from a page/memory event board to a recurrence-aware scheduling platform.

### What changed

New files only — no existing files modified:

| File | Purpose |
|------|---------|
| `src/models.py` | Domain dataclasses: `Workspace`, `Series`, `Occurrence`, `CheckIn`, `NotificationRule`, `DeliveryLog`, `ScheduleRule`, `OccurrenceOverrides` |
| `src/workspace_storage.py` | Firestore CRUD for workspaces, member role management, workspace invites |
| `src/series_storage.py` | Firestore CRUD for Series, Occurrences (batch write), CheckIns, NotificationRules, DeliveryLogs |
| `docs/migration-strategy.md` | Page->Workspace / Memory->Occurrence mapping + step-by-step migration plan |
| `tests/test_models.py` | 23 unit tests — serialization roundtrips for every model type |
| `tests/test_workspace_storage.py` | 16 unit tests — CRUD, member management, invite lifecycle (Firestore mocked) |

### Key design decisions

- **Additive only**: `page_storage.py` and `firestore_storage.py` are unchanged. All v1 API endpoints keep working.
- **`ScheduleRule`** encodes recurrence as a serializable dataclass (`frequency`, `weekdays`, `interval`, `until`, `count`) — feeds the Phase 2 recurrence engine.
- **`OccurrenceOverrides`** lets a single occurrence deviate from Series defaults without touching the series.
- **`member_roles` map** replaces the flat `owner_uids`/`member_uids` split with explicit roles: organizer, participant, teacher, assistant, student.
- **`DeliveryLog`** is append-only — notifications are auditable from day one.

### Tests

39 new tests, all green. 191 existing tests unaffected.

### What's next

**Phase 2**: recurrence engine (`src/recurrence.py`) — deterministic occurrence generation from `ScheduleRule`, timezone-aware, with skip/reschedule/complete override support.