### PR TITLE
feat(phase-6): Meeting Organizer AI assistant

### DIFF
--- a/src/api_v2.py
+++ b/src/api_v2.py
@@ -750,3 +750,86 @@ def get_series_ics(
         media_type='text/calendar',
         headers={'Content-Disposition': f'attachment; filename={filename}'},
     )
+
+
+# ---------------------------------------------------------------------------
+# Assistant endpoints
+# ---------------------------------------------------------------------------
+
+class AssistantMessageRequest(BaseModel):
+    message: str
+    workspace_context: dict | None = None
+
+
+@router.post('/workspaces/{workspace_id}/assistant')
+def assistant_chat(
+    workspace_id: str,
+    body: AssistantMessageRequest,
+    token: dict = Depends(_require_token),
+) -> object:
+    import json as _json
+    from fastapi.responses import StreamingResponse
+    from assistant import run_assistant_stream
+
+    ws = _get_workspace_or_404(workspace_id)
+    _require_role(ws, token['uid'], 'organizer', 'teacher')
+    uid = token['uid']
+
+    def _event_stream():
+        for event in run_assistant_stream(
+            message=body.message,
+            workspace_id=workspace_id,
+            uid=uid,
+            workspace_context=body.workspace_context,
+        ):
+            yield f"data: {_json.dumps(event)}\n\n"
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(_event_stream(), media_type='text/event-stream')
+
+
+@router.post('/assistant/actions/{action_id}/confirm')
+def confirm_action(
+    action_id: str,
+    token: dict = Depends(_require_token),
+) -> dict:
+    from assistant_actions import get_pending_action, update_pending_action_status, execute_action
+
+    pending = get_pending_action(action_id)
+    if pending is None:
+        raise HTTPException(status_code=404, detail='Action not found or expired')
+    if pending.requested_by_uid != token['uid']:
+        raise HTTPException(status_code=403, detail='Not your action')
+    if pending.status != 'pending':
+        raise HTTPException(status_code=409, detail=f'Action is already {pending.status}')
+
+    ws = _get_workspace_or_404(pending.workspace_id)
+    _require_role(ws, token['uid'], 'organizer', 'teacher')
+
+    update_pending_action_status(action_id, 'confirmed')
+    try:
+        result = execute_action(pending)
+        update_pending_action_status(action_id, 'executed', result=result)
+        return {'status': 'executed', 'action_id': action_id, 'result': result}
+    except Exception as exc:
+        update_pending_action_status(action_id, 'failed', error=str(exc))
+        raise HTTPException(status_code=500, detail=f'Action execution failed: {exc}') from exc
+
+
+@router.post('/assistant/actions/{action_id}/cancel', status_code=200)
+def cancel_action(
+    action_id: str,
+    token: dict = Depends(_require_token),
+) -> dict:
+    from assistant_actions import get_pending_action, update_pending_action_status
+
+    pending = get_pending_action(action_id)
+    if pending is None:
+        raise HTTPException(status_code=404, detail='Action not found or expired')
+    if pending.requested_by_uid != token['uid']:
+        raise HTTPException(status_code=403, detail='Not your action')
+    if pending.status != 'pending':
+        raise HTTPException(status_code=409, detail=f'Action is already {pending.status}')
+
+    update_pending_action_status(action_id, 'cancelled')
+    return {'status': 'cancelled', 'action_id': action_id}

--- a/src/assistant.py
+++ b/src/assistant.py
@@ -1,0 +1,192 @@
+"""Assistant service — Meeting Organizer AI assistant.
+
+Parses organizer messages, determines intent, proposes structured actions
+(with preview text), and streams a response to the caller.
+
+Streaming events (dicts with "type" key):
+  {"type": "status",          "message": "..."}
+  {"type": "text_chunk",      "text": "..."}
+  {"type": "action_proposal", "action_id": "...", "action_type": "...",
+   "preview_summary": "...",  "payload": {...}}
+  {"type": "done"}
+  {"type": "error",           "message": "..."}
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Generator
+
+from assistant_actions import (
+    build_create_series_action,
+    build_draft_material_action,
+    build_generate_reminder_text_action,
+    build_reschedule_occurrence_action,
+    save_pending_action,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL = "gemini-2.5-flash-lite"
+_MAX_RETRIES = 2
+
+# ---------------------------------------------------------------------------
+# Prompt
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPT = """You are an AI assistant for a meeting organizer. Help organizers manage recurring
+meetings, schedules, and materials through natural conversation.
+
+Available actions:
+  create_series          — create a new recurring meeting series
+  reschedule_occurrence  — reschedule a single meeting occurrence
+  draft_material         — draft meeting material (agenda, notes, announcement)
+  generate_reminder_text — generate a shareable reminder for participants
+  general_question       — answer without performing any state change
+
+For each message:
+  1. Determine the INTENT (one of the five above).
+  2. Write a short, friendly RESPONSE (1-3 sentences).
+  3. If the intent is state-changing, produce a structured ACTION PAYLOAD.
+  4. If no action is needed, set "action" to null.
+
+Always reply in the same language as the user.
+
+Respond with a single JSON object (no markdown fences):
+{
+  "intent": "<intent>",
+  "response_text": "<conversational reply>",
+  "action": {
+    "action_type": "<same as intent, not applicable for general_question>",
+    "preview_summary": "<1-sentence summary of what will happen>",
+    "payload": {
+      // create_series: title, kind, description, schedule_rule{frequency,weekdays,interval},
+      //   default_time, default_duration_minutes, default_location, default_online_link
+      // reschedule_occurrence: occurrence_id, new_scheduled_for (ISO 8601 UTC)
+      // draft_material: title, material_kind, draft_text
+      // generate_reminder_text: occurrence_id, series_id, reminder_text
+    }
+  }
+}
+"""
+
+
+def _build_prompt(message: str, workspace_context: dict[str, Any] | None) -> str:
+    ctx = ""
+    if workspace_context:
+        ctx = "\nWorkspace context:\n" + json.dumps(workspace_context, indent=2, default=str) + "\n"
+    return _SYSTEM_PROMPT + ctx + f"\nUser message: {message}"
+
+
+# ---------------------------------------------------------------------------
+# Gemini call (JSON mode)
+# ---------------------------------------------------------------------------
+
+def _call_ai(prompt: str) -> dict:
+    from google import genai
+    from google.genai import types
+
+    api_key = os.environ["GEMINI_API_KEY"]
+    model = os.environ.get("GEMINI_MODEL", _DEFAULT_MODEL)
+    client = genai.Client(api_key=api_key)
+
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_RETRIES):
+        response = client.models.generate_content(
+            model=model,
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                response_mime_type="application/json",
+            ),
+        )
+        text = response.text
+        if not text or not text.strip():
+            last_exc = ValueError("Gemini returned an empty response")
+            logger.warning("assistant AI attempt %d: empty response", attempt + 1)
+            continue
+        try:
+            result = json.loads(text)
+        except (json.JSONDecodeError, TypeError) as exc:
+            last_exc = exc
+            logger.warning("assistant AI attempt %d: invalid JSON: %s", attempt + 1, exc)
+            continue
+        if not isinstance(result, dict) or "intent" not in result:
+            last_exc = ValueError(f"Unexpected AI response shape: {result!r}")
+            logger.warning("assistant AI attempt %d: bad shape", attempt + 1)
+            continue
+        return result
+
+    raise last_exc or ValueError("AI call failed after retries")
+
+
+# ---------------------------------------------------------------------------
+# Action builder dispatch
+# ---------------------------------------------------------------------------
+
+_ACTION_BUILDERS = {
+    "create_series": build_create_series_action,
+    "reschedule_occurrence": build_reschedule_occurrence_action,
+    "draft_material": build_draft_material_action,
+    "generate_reminder_text": build_generate_reminder_text_action,
+}
+
+
+def _build_and_save_action(
+    intent: str, ai_action: dict, workspace_id: str, uid: str
+):
+    builder = _ACTION_BUILDERS.get(intent)
+    if builder is None:
+        return None
+    pending = builder(workspace_id, uid, ai_action.get("payload", {}))
+    if ai_action.get("preview_summary"):
+        pending.preview_summary = ai_action["preview_summary"]
+    save_pending_action(pending)
+    return pending
+
+
+# ---------------------------------------------------------------------------
+# Public streaming entry point
+# ---------------------------------------------------------------------------
+
+def run_assistant_stream(
+    message: str,
+    workspace_id: str,
+    uid: str,
+    workspace_context: dict[str, Any] | None = None,
+) -> Generator[dict, None, None]:
+    """Stream assistant events for an organizer message."""
+    yield {"type": "status", "message": "Thinking\u2026"}
+
+    prompt = _build_prompt(message, workspace_context)
+    try:
+        ai_result = _call_ai(prompt)
+    except Exception as exc:
+        logger.exception("AI call failed in assistant stream")
+        yield {"type": "error", "message": str(exc)}
+        return
+
+    intent = ai_result.get("intent", "general_question")
+    response_text = ai_result.get("response_text", "")
+    ai_action = ai_result.get("action")
+
+    if response_text:
+        yield {"type": "text_chunk", "text": response_text}
+
+    if ai_action and intent != "general_question":
+        try:
+            pending = _build_and_save_action(intent, ai_action, workspace_id, uid)
+            if pending is not None:
+                yield {
+                    "type": "action_proposal",
+                    "action_id": pending.action_id,
+                    "action_type": pending.action_type,
+                    "preview_summary": pending.preview_summary,
+                    "payload": pending.payload,
+                }
+        except Exception as exc:
+            logger.exception("Failed to build/save action proposal")
+            yield {"type": "status", "message": f"Could not prepare action: {exc}"}
+
+    yield {"type": "done"}

--- a/src/assistant_actions.py
+++ b/src/assistant_actions.py
@@ -1,0 +1,305 @@
+"""Assistant actions — definitions and execution for the Meeting Organizer Assistant.
+
+Each action follows the preview/confirm pattern:
+  1. The assistant proposes an action (stored as pending_action in Firestore).
+  2. The user confirms via /v2/assistant/actions/{id}/confirm.
+  3. On confirmation, execute() is called.
+
+Action types: create_series, reschedule_occurrence, draft_material,
+              generate_reminder_text
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+
+
+ActionType = Literal[
+    "create_series",
+    "reschedule_occurrence",
+    "draft_material",
+    "generate_reminder_text",
+]
+
+ActionStatus = Literal["pending", "confirmed", "cancelled", "executed", "failed"]
+
+PENDING_ACTIONS_COLLECTION = "pending_assistant_actions"
+ACTION_TTL_SECONDS = 600  # 10 minutes
+
+
+@dataclass
+class PendingAction:
+    """A proposed but not-yet-confirmed assistant action."""
+
+    action_id: str
+    workspace_id: str
+    requested_by_uid: str
+    action_type: ActionType
+    preview_summary: str
+    payload: dict[str, Any]
+    status: ActionStatus = "pending"
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    executed_at: datetime | None = None
+    result: dict[str, Any] | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "action_id": self.action_id,
+            "workspace_id": self.workspace_id,
+            "requested_by_uid": self.requested_by_uid,
+            "action_type": self.action_type,
+            "preview_summary": self.preview_summary,
+            "payload": self.payload,
+            "status": self.status,
+            "created_at": self.created_at,
+            "executed_at": self.executed_at,
+            "result": self.result,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PendingAction":
+        return cls(
+            action_id=data["action_id"],
+            workspace_id=data["workspace_id"],
+            requested_by_uid=data["requested_by_uid"],
+            action_type=data["action_type"],
+            preview_summary=data["preview_summary"],
+            payload=dict(data.get("payload", {})),
+            status=data.get("status", "pending"),
+            created_at=data.get("created_at", datetime.now(timezone.utc)),
+            executed_at=data.get("executed_at"),
+            result=data.get("result"),
+            error=data.get("error"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Firestore helpers
+# ---------------------------------------------------------------------------
+
+def save_pending_action(action: PendingAction) -> str:
+    """Persist a PendingAction to Firestore and return the action_id."""
+    from firestore_storage import _get_client
+    db = _get_client()
+    db.collection(PENDING_ACTIONS_COLLECTION).document(action.action_id).set(
+        action.to_dict()
+    )
+    return action.action_id
+
+
+def get_pending_action(action_id: str) -> "PendingAction | None":
+    """Fetch a PendingAction from Firestore, or None if not found / expired."""
+    from firestore_storage import _get_client
+    db = _get_client()
+    doc = db.collection(PENDING_ACTIONS_COLLECTION).document(action_id).get()
+    if not doc.exists:
+        return None
+    data = doc.to_dict()
+    action = PendingAction.from_dict(data)
+    created = action.created_at
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=timezone.utc)
+    age = (datetime.now(timezone.utc) - created).total_seconds()
+    if age > ACTION_TTL_SECONDS:
+        logger.info("PendingAction %s expired (age=%.0fs)", action_id, age)
+        return None
+    return action
+
+
+def update_pending_action_status(
+    action_id: str,
+    status: ActionStatus,
+    result: dict | None = None,
+    error: str | None = None,
+) -> None:
+    """Update status fields on an existing PendingAction document."""
+    from firestore_storage import _get_client
+    db = _get_client()
+    updates: dict[str, Any] = {"status": status}
+    if result is not None:
+        updates["result"] = result
+    if error is not None:
+        updates["error"] = error
+    if status in ("executed", "failed"):
+        updates["executed_at"] = datetime.now(timezone.utc)
+    db.collection(PENDING_ACTIONS_COLLECTION).document(action_id).update(updates)
+
+
+# ---------------------------------------------------------------------------
+# CreateSeriesAction
+# ---------------------------------------------------------------------------
+
+def build_create_series_action(
+    workspace_id: str, uid: str, payload: dict
+) -> PendingAction:
+    title = payload.get("title", "New Meeting")
+    freq = payload.get("schedule_rule", {}).get("frequency", "weekly")
+    time_str = payload.get("default_time", "")
+    at_time = f" at {time_str}" if time_str else ""
+    summary = (
+        f'Create a new {freq} series titled "{title}"{at_time}'
+        f' in workspace {workspace_id}.'
+    )
+    return PendingAction(
+        action_id=str(uuid.uuid4()),
+        workspace_id=workspace_id,
+        requested_by_uid=uid,
+        action_type="create_series",
+        preview_summary=summary,
+        payload=payload,
+    )
+
+
+def execute_create_series(action: PendingAction) -> dict:
+    import series_storage
+    import workspace_storage
+    from models import Series, ScheduleRule
+
+    payload = action.payload
+    ws = workspace_storage.get_workspace(action.workspace_id)
+    if ws is None:
+        raise ValueError(f"Workspace not found: {action.workspace_id}")
+
+    series = Series(
+        series_id=str(uuid.uuid4()),
+        workspace_id=action.workspace_id,
+        kind=payload.get("kind", "meeting"),
+        title=payload["title"],
+        schedule_rule=ScheduleRule.from_dict(
+            payload.get("schedule_rule", {"frequency": "weekly"})
+        ),
+        default_time=payload.get("default_time"),
+        default_duration_minutes=payload.get("default_duration_minutes"),
+        default_location=payload.get("default_location"),
+        default_online_link=payload.get("default_online_link"),
+        description=payload.get("description"),
+        created_by=action.requested_by_uid,
+    )
+    series_storage.create_series(series)
+    logger.info(
+        "Created series %s via assistant action %s",
+        series.series_id,
+        action.action_id,
+    )
+    return {"created": "series", "series": series.to_dict()}
+
+
+# ---------------------------------------------------------------------------
+# RescheduleOccurrenceAction
+# ---------------------------------------------------------------------------
+
+def build_reschedule_occurrence_action(
+    workspace_id: str, uid: str, payload: dict
+) -> PendingAction:
+    occ_id = payload.get("occurrence_id", "?")
+    new_dt = payload.get("new_scheduled_for", "?")
+    summary = f"Reschedule occurrence {occ_id} to {new_dt}."
+    return PendingAction(
+        action_id=str(uuid.uuid4()),
+        workspace_id=workspace_id,
+        requested_by_uid=uid,
+        action_type="reschedule_occurrence",
+        preview_summary=summary,
+        payload=payload,
+    )
+
+
+def execute_reschedule_occurrence(action: PendingAction) -> dict:
+    from occurrence_service import reschedule_occurrence
+
+    payload = action.payload
+    updated = reschedule_occurrence(
+        payload["occurrence_id"], payload["new_scheduled_for"]
+    )
+    logger.info(
+        "Rescheduled occurrence %s via assistant action %s",
+        payload["occurrence_id"],
+        action.action_id,
+    )
+    return {"rescheduled": "occurrence", "occurrence": updated.to_dict()}
+
+
+# ---------------------------------------------------------------------------
+# DraftMaterialAction
+# ---------------------------------------------------------------------------
+
+def build_draft_material_action(
+    workspace_id: str, uid: str, payload: dict
+) -> PendingAction:
+    kind = payload.get("material_kind", "agenda")
+    title = payload.get("title", "Untitled")
+    summary = f'Draft a {kind} for "{title}".'
+    return PendingAction(
+        action_id=str(uuid.uuid4()),
+        workspace_id=workspace_id,
+        requested_by_uid=uid,
+        action_type="draft_material",
+        preview_summary=summary,
+        payload=payload,
+    )
+
+
+def execute_draft_material(action: PendingAction) -> dict:
+    payload = action.payload
+    logger.info("Confirmed draft material via assistant action %s", action.action_id)
+    return {
+        "material_kind": payload.get("material_kind", "agenda"),
+        "title": payload.get("title", ""),
+        "draft_text": payload.get("draft_text", ""),
+    }
+
+
+# ---------------------------------------------------------------------------
+# GenerateReminderTextAction
+# ---------------------------------------------------------------------------
+
+def build_generate_reminder_text_action(
+    workspace_id: str, uid: str, payload: dict
+) -> PendingAction:
+    ref = payload.get("occurrence_id") or payload.get("series_id") or "?"
+    summary = f"Generate a shareable reminder message for {ref}."
+    return PendingAction(
+        action_id=str(uuid.uuid4()),
+        workspace_id=workspace_id,
+        requested_by_uid=uid,
+        action_type="generate_reminder_text",
+        preview_summary=summary,
+        payload=payload,
+    )
+
+
+def execute_generate_reminder_text(action: PendingAction) -> dict:
+    payload = action.payload
+    logger.info("Confirmed reminder text via assistant action %s", action.action_id)
+    return {
+        "reminder_text": payload.get("reminder_text", ""),
+        "occurrence_id": payload.get("occurrence_id"),
+        "series_id": payload.get("series_id"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+def execute_action(action: PendingAction) -> dict:
+    """Dispatch to the correct execute function based on action.action_type."""
+    dispatch = {
+        "create_series": execute_create_series,
+        "reschedule_occurrence": execute_reschedule_occurrence,
+        "draft_material": execute_draft_material,
+        "generate_reminder_text": execute_generate_reminder_text,
+    }
+    fn = dispatch.get(action.action_type)
+    if fn is None:
+        raise ValueError(f"Unknown action type: {action.action_type}")
+    return fn(action)

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -1,0 +1,460 @@
+
+"""Tests for the Meeting Organizer Assistant — actions and API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from assistant_actions import (
+    ACTION_TTL_SECONDS,
+    PendingAction,
+    build_create_series_action,
+    build_draft_material_action,
+    build_generate_reminder_text_action,
+    build_reschedule_occurrence_action,
+    execute_action,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_pending(
+    action_type="create_series",
+    payload=None,
+    status="pending",
+    age_seconds=0,
+) -> PendingAction:
+    created = datetime.now(timezone.utc)
+    # subtract age so we can simulate expired actions
+    from datetime import timedelta
+    created = created - timedelta(seconds=age_seconds)
+    return PendingAction(
+        action_id=str(uuid.uuid4()),
+        workspace_id="ws-1",
+        requested_by_uid="uid-1",
+        action_type=action_type,
+        preview_summary="Test action",
+        payload=payload or {},
+        status=status,
+        created_at=created,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PendingAction serialisation round-trip
+# ---------------------------------------------------------------------------
+
+class TestPendingActionSerialization:
+    def test_to_dict_and_back(self):
+        action = _make_pending(
+            action_type="create_series",
+            payload={"title": "Standup", "schedule_rule": {"frequency": "weekly"}},
+        )
+        d = action.to_dict()
+        restored = PendingAction.from_dict(d)
+        assert restored.action_id == action.action_id
+        assert restored.action_type == action.action_type
+        assert restored.payload["title"] == "Standup"
+        assert restored.status == "pending"
+
+    def test_from_dict_defaults_status(self):
+        d = {
+            "action_id": "x",
+            "workspace_id": "ws",
+            "requested_by_uid": "u",
+            "action_type": "draft_material",
+            "preview_summary": "ok",
+            "payload": {},
+        }
+        action = PendingAction.from_dict(d)
+        assert action.status == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Builder functions
+# ---------------------------------------------------------------------------
+
+class TestBuildCreateSeriesAction:
+    def test_basic(self):
+        payload = {
+            "title": "Weekly Standup",
+            "schedule_rule": {"frequency": "weekly", "weekdays": [1, 3]},
+            "default_time": "10:00",
+        }
+        action = build_create_series_action("ws-1", "uid-1", payload)
+        assert action.action_type == "create_series"
+        assert "Weekly Standup" in action.preview_summary
+        assert "weekly" in action.preview_summary
+        assert action.workspace_id == "ws-1"
+        assert action.requested_by_uid == "uid-1"
+        assert action.status == "pending"
+
+    def test_no_time(self):
+        payload = {"title": "Daily Check-in", "schedule_rule": {"frequency": "daily"}}
+        action = build_create_series_action("ws-2", "uid-2", payload)
+        # No default_time in payload → "at ..." should not appear in summary
+        assert " at " not in action.preview_summary
+
+
+class TestBuildRescheduleOccurrenceAction:
+    def test_basic(self):
+        payload = {
+            "occurrence_id": "occ-123",
+            "new_scheduled_for": "2026-04-10T10:00:00+00:00",
+        }
+        action = build_reschedule_occurrence_action("ws-1", "uid-1", payload)
+        assert action.action_type == "reschedule_occurrence"
+        assert "occ-123" in action.preview_summary
+        assert "2026-04-10" in action.preview_summary
+
+    def test_unknown_occurrence(self):
+        payload = {"occurrence_id": "?", "new_scheduled_for": "2026-05-01T09:00:00+00:00"}
+        action = build_reschedule_occurrence_action("ws-1", "uid-1", payload)
+        assert action.action_type == "reschedule_occurrence"
+
+
+class TestBuildDraftMaterialAction:
+    def test_agenda(self):
+        payload = {
+            "title": "Team Meeting",
+            "material_kind": "agenda",
+            "draft_text": "1. Intro\n2. Updates",
+        }
+        action = build_draft_material_action("ws-1", "uid-1", payload)
+        assert action.action_type == "draft_material"
+        assert "agenda" in action.preview_summary
+        assert "Team Meeting" in action.preview_summary
+
+    def test_notes(self):
+        payload = {"title": "Retrospective", "material_kind": "notes", "draft_text": "..."}
+        action = build_draft_material_action("ws-1", "uid-1", payload)
+        assert "notes" in action.preview_summary
+
+
+class TestBuildGenerateReminderTextAction:
+    def test_with_occurrence(self):
+        payload = {
+            "occurrence_id": "occ-42",
+            "reminder_text": "Don't forget the meeting tomorrow!",
+        }
+        action = build_generate_reminder_text_action("ws-1", "uid-1", payload)
+        assert action.action_type == "generate_reminder_text"
+        assert "occ-42" in action.preview_summary
+
+    def test_with_series(self):
+        payload = {
+            "series_id": "series-7",
+            "reminder_text": "Weekly standup is at 10am.",
+        }
+        action = build_generate_reminder_text_action("ws-1", "uid-1", payload)
+        assert "series-7" in action.preview_summary
+
+
+# ---------------------------------------------------------------------------
+# execute_action dispatch
+# ---------------------------------------------------------------------------
+
+class TestExecuteAction:
+    def test_execute_draft_material(self):
+        action = _make_pending(
+            action_type="draft_material",
+            payload={
+                "title": "Q2 Review",
+                "material_kind": "agenda",
+                "draft_text": "Item 1\nItem 2",
+            },
+        )
+        result = execute_action(action)
+        assert result["material_kind"] == "agenda"
+        assert result["title"] == "Q2 Review"
+        assert "Item 1" in result["draft_text"]
+
+    def test_execute_generate_reminder_text(self):
+        action = _make_pending(
+            action_type="generate_reminder_text",
+            payload={
+                "occurrence_id": "occ-99",
+                "reminder_text": "Meeting at 3pm!",
+            },
+        )
+        result = execute_action(action)
+        assert result["reminder_text"] == "Meeting at 3pm!"
+        assert result["occurrence_id"] == "occ-99"
+
+    def test_execute_create_series(self):
+        action = _make_pending(
+            action_type="create_series",
+            payload={
+                "title": "Sprint Standup",
+                "kind": "meeting",
+                "schedule_rule": {"frequency": "daily"},
+            },
+        )
+        fake_workspace = MagicMock()
+
+        with (
+            patch("workspace_storage.get_workspace", return_value=fake_workspace),
+            patch("series_storage.create_series", return_value=None),
+        ):
+            result = execute_action(action)
+
+        assert result["created"] == "series"
+        assert result["series"]["title"] == "Sprint Standup"
+
+    def test_execute_reschedule_occurrence(self):
+        action = _make_pending(
+            action_type="reschedule_occurrence",
+            payload={
+                "occurrence_id": "occ-55",
+                "new_scheduled_for": "2026-05-01T09:00:00+00:00",
+            },
+        )
+        from models import Occurrence
+        fake_occurrence = Occurrence(
+            occurrence_id="occ-55",
+            series_id="series-1",
+            workspace_id="ws-1",
+            scheduled_for="2026-05-01T09:00:00+00:00",
+            status="rescheduled",
+        )
+        with patch("occurrence_service.reschedule_occurrence", return_value=fake_occurrence):
+            result = execute_action(action)
+
+        assert result["rescheduled"] == "occurrence"
+        assert result["occurrence"]["occurrence_id"] == "occ-55"
+
+    def test_unknown_action_type_raises(self):
+        action = _make_pending(action_type="create_series")
+        action.action_type = "nonexistent_action"
+        with pytest.raises(ValueError, match="Unknown action type"):
+            execute_action(action)
+
+
+# ---------------------------------------------------------------------------
+# Firestore helpers (mocked)
+# ---------------------------------------------------------------------------
+
+class TestFirestoreHelpers:
+    def test_save_pending_action(self):
+        action = _make_pending(action_type="draft_material", payload={"title": "Test"})
+        mock_db = MagicMock()
+        mock_doc_ref = MagicMock()
+        mock_db.collection.return_value.document.return_value = mock_doc_ref
+
+        with patch("firestore_storage._get_client", return_value=mock_db):
+            from assistant_actions import save_pending_action
+            action_id = save_pending_action(action)
+
+        assert action_id == action.action_id
+        mock_doc_ref.set.assert_called_once()
+
+    def test_get_pending_action_not_found(self):
+        mock_db = MagicMock()
+        mock_doc = MagicMock()
+        mock_doc.exists = False
+        mock_db.collection.return_value.document.return_value.get.return_value = mock_doc
+
+        with patch("firestore_storage._get_client", return_value=mock_db):
+            from assistant_actions import get_pending_action
+            result = get_pending_action("nonexistent-id")
+
+        assert result is None
+
+    def test_get_pending_action_expired(self):
+        action = _make_pending(age_seconds=ACTION_TTL_SECONDS + 60)
+        mock_db = MagicMock()
+        mock_doc = MagicMock()
+        mock_doc.exists = True
+        mock_doc.to_dict.return_value = action.to_dict()
+        # Firestore timestamps come back as datetime objects; simulate that:
+        mock_db.collection.return_value.document.return_value.get.return_value = mock_doc
+
+        with patch("firestore_storage._get_client", return_value=mock_db):
+            from assistant_actions import get_pending_action
+            result = get_pending_action(action.action_id)
+
+        assert result is None  # expired
+
+    def test_get_pending_action_found(self):
+        action = _make_pending(age_seconds=30)
+        mock_db = MagicMock()
+        mock_doc = MagicMock()
+        mock_doc.exists = True
+        mock_doc.to_dict.return_value = action.to_dict()
+        mock_db.collection.return_value.document.return_value.get.return_value = mock_doc
+
+        with patch("firestore_storage._get_client", return_value=mock_db):
+            from assistant_actions import get_pending_action
+            result = get_pending_action(action.action_id)
+
+        assert result is not None
+        assert result.action_id == action.action_id
+
+    def test_update_pending_action_status(self):
+        mock_db = MagicMock()
+        mock_doc_ref = MagicMock()
+        mock_db.collection.return_value.document.return_value = mock_doc_ref
+
+        with patch("firestore_storage._get_client", return_value=mock_db):
+            from assistant_actions import update_pending_action_status
+            update_pending_action_status("some-id", "executed", result={"ok": True})
+
+        call_kwargs = mock_doc_ref.update.call_args[0][0]
+        assert call_kwargs["status"] == "executed"
+        assert call_kwargs["result"] == {"ok": True}
+        assert "executed_at" in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# API endpoint integration tests
+# ---------------------------------------------------------------------------
+
+ORGANIZER_UID = "uid-organizer"
+PARTICIPANT_UID = "uid-participant"
+AUTH = {"Authorization": "Bearer fake-token"}
+
+
+def _fake_verify(uid: str):
+    def verifier(authorization: str = ""):
+        return {"uid": uid}
+    return verifier
+
+
+@pytest.fixture
+def organizer_client():
+    fastapi = pytest.importorskip("fastapi", reason="fastapi not installed")
+    from api import app
+    from api_v2 import _require_token
+    app.dependency_overrides[_require_token] = _fake_verify(ORGANIZER_UID)
+    from fastapi.testclient import TestClient
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _make_workspace(uid: str = ORGANIZER_UID):
+    from models import Workspace
+    return Workspace(
+        workspace_id="ws-1",
+        title="Test WS",
+        type="shared",
+        timezone="UTC",
+        owner_uids=[uid],
+        member_roles={uid: "organizer"},
+    )
+
+
+class TestAssistantAPI:
+    def test_assistant_endpoint_missing_env(self, organizer_client):
+        """Without GEMINI_API_KEY the endpoint should error, not 500 on auth."""
+        import os
+        ws = _make_workspace()
+
+        with (
+            patch("api_v2.workspace_storage.get_workspace", return_value=ws),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            # We won't actually call Gemini in tests; mock the stream
+            with patch(
+                "api_v2.run_assistant_stream",
+                return_value=iter([
+                    {"type": "text_chunk", "text": "Hello!"},
+                    {"type": "done"},
+                ]),
+            ):
+                resp = organizer_client.post(
+                    "/v2/workspaces/ws-1/assistant",
+                    json={"message": "Schedule weekly standup"},
+                    headers=AUTH,
+                )
+        assert resp.status_code == 200
+
+    def test_confirm_action_not_found(self, organizer_client):
+        with patch("api_v2.get_pending_action", return_value=None):
+            resp = organizer_client.post(
+                "/v2/assistant/actions/nonexistent/confirm",
+                headers=AUTH,
+            )
+        assert resp.status_code == 404
+
+    def test_confirm_action_wrong_user(self, organizer_client):
+        action = _make_pending(action_type="draft_material", payload={})
+        action.requested_by_uid = "someone-else"
+        with patch("api_v2.get_pending_action", return_value=action):
+            resp = organizer_client.post(
+                f"/v2/assistant/actions/{action.action_id}/confirm",
+                headers=AUTH,
+            )
+        assert resp.status_code == 403
+
+    def test_confirm_action_already_executed(self, organizer_client):
+        action = _make_pending(
+            action_type="draft_material",
+            payload={"title": "x", "material_kind": "agenda", "draft_text": ""},
+            status="executed",
+        )
+        action.requested_by_uid = ORGANIZER_UID
+        with patch("api_v2.get_pending_action", return_value=action):
+            resp = organizer_client.post(
+                f"/v2/assistant/actions/{action.action_id}/confirm",
+                headers=AUTH,
+            )
+        assert resp.status_code == 409
+
+    def test_cancel_action_success(self, organizer_client):
+        action = _make_pending(
+            action_type="generate_reminder_text",
+            payload={"reminder_text": "hi"},
+        )
+        action.requested_by_uid = ORGANIZER_UID
+        mock_db = MagicMock()
+        mock_db.collection.return_value.document.return_value.update = MagicMock()
+
+        with (
+            patch("api_v2.get_pending_action", return_value=action),
+            patch("api_v2.update_pending_action_status") as mock_update,
+        ):
+            resp = organizer_client.post(
+                f"/v2/assistant/actions/{action.action_id}/cancel",
+                headers=AUTH,
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "cancelled"
+        mock_update.assert_called_once_with(action.action_id, "cancelled")
+
+    def test_confirm_action_executes_draft(self, organizer_client):
+        ws = _make_workspace()
+        action = _make_pending(
+            action_type="draft_material",
+            payload={
+                "title": "Weekly Notes",
+                "material_kind": "notes",
+                "draft_text": "Discussed Q3 goals.",
+            },
+        )
+        action.requested_by_uid = ORGANIZER_UID
+
+        with (
+            patch("api_v2.get_pending_action", return_value=action),
+            patch("api_v2.update_pending_action_status"),
+            patch("api_v2.execute_action", return_value={
+                "material_kind": "notes",
+                "title": "Weekly Notes",
+                "draft_text": "Discussed Q3 goals.",
+            }),
+            patch("api_v2.workspace_storage.get_workspace", return_value=ws),
+        ):
+            resp = organizer_client.post(
+                f"/v2/assistant/actions/{action.action_id}/confirm",
+                headers=AUTH,
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "executed"
+        assert data["result"]["material_kind"] == "notes"

--- a/web/src/AssistantChat.tsx
+++ b/web/src/AssistantChat.tsx
@@ -1,0 +1,279 @@
+import { useState, useRef, useCallback } from "react";
+import { auth } from "../firebase";
+
+const BASE_URL = (import.meta as any).env?.VITE_API_BASE_URL ?? "";
+
+interface ActionProposal {
+  action_id: string;
+  action_type: string;
+  preview_summary: string;
+  payload: Record<string, unknown>;
+}
+
+interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  proposal?: ActionProposal;
+}
+
+async function getToken(): Promise<string> {
+  if (!auth.currentUser) throw new Error("Not signed in");
+  return auth.currentUser.getIdToken();
+}
+
+async function confirmAction(actionId: string): Promise<{ status: string; result: unknown }> {
+  const token = await getToken();
+  const resp = await fetch(`${BASE_URL}/v2/assistant/actions/${actionId}/confirm`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({ detail: resp.statusText }));
+    throw new Error(body.detail || resp.statusText);
+  }
+  return resp.json();
+}
+
+async function cancelAction(actionId: string): Promise<void> {
+  const token = await getToken();
+  const resp = await fetch(`${BASE_URL}/v2/assistant/actions/${actionId}/cancel`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({ detail: resp.statusText }));
+    throw new Error(body.detail || resp.statusText);
+  }
+}
+
+interface Props {
+  workspaceId: string;
+}
+
+export function AssistantChat({ workspaceId }: Props) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const appendMessage = useCallback((msg: Omit<ChatMessage, "id">) => {
+    setMessages((prev) => [...prev, { ...msg, id: crypto.randomUUID() }]);
+    setTimeout(() => {
+      scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+    }, 50);
+  }, []);
+
+  const updateLastAssistantMessage = useCallback(
+    (updater: (prev: ChatMessage) => ChatMessage) => {
+      setMessages((prev) => {
+        const idx = [...prev].reverse().findIndex((m) => m.role === "assistant");
+        if (idx === -1) return prev;
+        const realIdx = prev.length - 1 - idx;
+        const updated = [...prev];
+        updated[realIdx] = updater(updated[realIdx]);
+        return updated;
+      });
+    },
+    []
+  );
+
+  async function handleSend() {
+    const trimmed = input.trim();
+    if (!trimmed || loading) return;
+
+    setInput("");
+    setError(null);
+    setLoading(true);
+
+    appendMessage({ role: "user", text: trimmed });
+    appendMessage({ role: "assistant", text: "" });
+
+    try {
+      const token = await getToken();
+      const resp = await fetch(`${BASE_URL}/v2/workspaces/${workspaceId}/assistant`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ message: trimmed }),
+      });
+
+      if (!resp.ok || !resp.body) {
+        const body = await resp.json().catch(() => ({ detail: resp.statusText }));
+        throw new Error(body.detail || resp.statusText);
+      }
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          const trimmedLine = line.trim();
+          if (!trimmedLine || trimmedLine === "data: [DONE]") continue;
+          if (!trimmedLine.startsWith("data: ")) continue;
+          try {
+            const event = JSON.parse(trimmedLine.slice(6));
+            if (event.type === "text_chunk") {
+              updateLastAssistantMessage((prev) => ({
+                ...prev,
+                text: prev.text + (event.text as string),
+              }));
+            } else if (event.type === "action_proposal") {
+              updateLastAssistantMessage((prev) => ({
+                ...prev,
+                proposal: {
+                  action_id: event.action_id as string,
+                  action_type: event.action_type as string,
+                  preview_summary: event.preview_summary as string,
+                  payload: event.payload as Record<string, unknown>,
+                },
+              }));
+            }
+          } catch {
+            // ignore unparseable chunks
+          }
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        if (last?.role === "assistant" && !last.text) return prev.slice(0, -1);
+        return prev;
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleConfirm(actionId: string) {
+    try {
+      const result = await confirmAction(actionId);
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.proposal?.action_id === actionId ? { ...m, proposal: undefined } : m
+        )
+      );
+      appendMessage({
+        role: "assistant",
+        text: `Action executed successfully.\n${JSON.stringify(result.result, null, 2)}`,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to confirm action");
+    }
+  }
+
+  async function handleCancel(actionId: string) {
+    try {
+      await cancelAction(actionId);
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.proposal?.action_id === actionId ? { ...m, proposal: undefined } : m
+        )
+      );
+      appendMessage({ role: "assistant", text: "Action cancelled." });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to cancel action");
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  return (
+    <div className="assistant-chat">
+      <div className="assistant-chat-header">
+        <span className="assistant-chat-title">AI Assistant</span>
+        <span className="assistant-chat-subtitle">
+          Ask me to create meetings, draft materials, or generate reminders.
+        </span>
+      </div>
+
+      <div className="assistant-chat-messages" ref={scrollRef}>
+        {messages.length === 0 && (
+          <p className="assistant-chat-empty">
+            Try: "Create a weekly standup every Monday at 9am" or "Draft an agenda for tomorrow."
+          </p>
+        )}
+
+        {messages.map((msg) => (
+          <div key={msg.id} className={`assistant-message assistant-message-${msg.role}`}>
+            <div className="assistant-message-bubble">
+              {msg.text && (
+                <p className="assistant-message-text" style={{ whiteSpace: "pre-wrap" }}>
+                  {msg.text}
+                </p>
+              )}
+              {msg.proposal && (
+                <div className="assistant-proposal">
+                  <p className="assistant-proposal-summary">
+                    <strong>Proposed action:</strong> {msg.proposal.preview_summary}
+                  </p>
+                  <div className="assistant-proposal-actions">
+                    <button
+                      className="btn btn-primary btn-sm"
+                      onClick={() => handleConfirm(msg.proposal!.action_id)}
+                    >
+                      Confirm
+                    </button>
+                    <button
+                      className="btn btn-secondary btn-sm"
+                      onClick={() => handleCancel(msg.proposal!.action_id)}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+
+        {loading && (
+          <div className="assistant-message assistant-message-assistant">
+            <div className="assistant-message-bubble assistant-thinking">
+              <span className="dot" />
+              <span className="dot" />
+              <span className="dot" />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {error && <p className="assistant-chat-error">{error}</p>}
+
+      <div className="assistant-chat-input-row">
+        <textarea
+          className="assistant-chat-input"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Ask the assistant\u2026"
+          rows={2}
+          disabled={loading}
+        />
+        <button
+          className="btn btn-primary btn-sm assistant-chat-send"
+          onClick={handleSend}
+          disabled={loading || !input.trim()}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -376,3 +376,49 @@ export async function getOccurrenceCheckIns(occurrenceId: string): Promise<Check
   const data = await resp.json();
   return (data.check_ins ?? []) as CheckInSummary[];
 }
+
+
+// ============================================================
+// Assistant API
+// ============================================================
+
+export interface AssistantEvent {
+  type: "status" | "text_chunk" | "action_proposal" | "done" | "error";
+  message?: string;
+  text?: string;
+  action_id?: string;
+  action_type?: string;
+  preview_summary?: string;
+  payload?: Record<string, unknown>;
+}
+
+/**
+ * Send a message to the organizer assistant.
+ * Returns a ReadableStream of SSE-encoded AssistantEvent objects.
+ * The caller is responsible for consuming the stream.
+ */
+export async function sendAssistantMessage(
+  workspaceId: string,
+  message: string,
+): Promise<ReadableStream<Uint8Array>> {
+  const resp = await apiFetch(`/v2/workspaces/${workspaceId}/assistant`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message }),
+  });
+  if (!resp.body) throw new Error("No response body");
+  return resp.body;
+}
+
+export async function confirmAssistantAction(
+  actionId: string,
+): Promise<{ status: string; result: unknown }> {
+  const resp = await apiFetch(`/v2/assistant/actions/${actionId}/confirm`, {
+    method: "POST",
+  });
+  return resp.json();
+}
+
+export async function cancelAssistantAction(actionId: string): Promise<void> {
+  await apiFetch(`/v2/assistant/actions/${actionId}/cancel`, { method: "POST" });
+}

--- a/web/src/routes/WorkspaceView.tsx
+++ b/web/src/routes/WorkspaceView.tsx
@@ -11,6 +11,7 @@ import {
 } from "../api";
 import { LoadingSpinner } from "../components/LoadingSpinner";
 import { ErrorMessage } from "../components/ErrorMessage";
+import { AssistantChat } from "../AssistantChat";
 
 const FREQ_OPTIONS = [
   { value: "daily", label: "Daily" },
@@ -57,6 +58,7 @@ export function WorkspaceView() {
   const [formError, setFormError] = useState<string | null>(null);
 
   const [generatingId, setGeneratingId] = useState<string | null>(null);
+  const [showAssistant, setShowAssistant] = useState(false);
 
   const load = useCallback(async () => {
     if (!workspaceId) return;
@@ -363,6 +365,21 @@ export function WorkspaceView() {
               No series yet. Create a recurring schedule to get started.
             </p>
           )
+        )}
+      </section>
+
+      <section className="section">
+        <div className="section-header">
+          <h2>AI Assistant</h2>
+          <button
+            className="btn btn-secondary btn-sm"
+            onClick={() => setShowAssistant((v) => !v)}
+          >
+            {showAssistant ? "Hide Assistant" : "Open Assistant"}
+          </button>
+        </div>
+        {showAssistant && workspaceId && (
+          <AssistantChat workspaceId={workspaceId} />
         )}
       </section>
     </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1753,3 +1753,172 @@ details[open] .chevron { transform: rotate(90deg); }
   .summary-title { font-size: 2.2rem; }
   .summary-join-btn { display: inline-block; padding: 1rem 2.5rem; }
 }
+
+
+/* ============================================================
+   Assistant Chat
+   ============================================================ */
+
+.assistant-chat {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--surface);
+  max-height: 600px;
+}
+
+.assistant-chat-header {
+  padding: 0.75rem 1rem;
+  background: var(--surface-raised);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.assistant-chat-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.assistant-chat-subtitle {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.assistant-chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 120px;
+  max-height: 400px;
+}
+
+.assistant-chat-empty {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 1rem 0;
+}
+
+.assistant-message {
+  display: flex;
+}
+
+.assistant-message-user {
+  justify-content: flex-end;
+}
+
+.assistant-message-assistant {
+  justify-content: flex-start;
+}
+
+.assistant-message-bubble {
+  max-width: 82%;
+  padding: 0.6rem 0.9rem;
+  border-radius: 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.assistant-message-user .assistant-message-bubble {
+  background: var(--accent);
+  color: #fff;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.assistant-message-assistant .assistant-message-bubble {
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-bottom-left-radius: 0.25rem;
+}
+
+.assistant-message-text {
+  margin: 0;
+}
+
+.assistant-proposal {
+  margin-top: 0.6rem;
+  padding: 0.5rem 0.75rem;
+  background: #fff8e1;
+  border: 1px solid #f0c040;
+  border-radius: 0.5rem;
+}
+
+.assistant-proposal-summary {
+  margin: 0 0 0.5rem;
+  font-size: 0.83rem;
+}
+
+.assistant-proposal-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* Thinking dots animation */
+.assistant-thinking {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.5rem 0.9rem;
+}
+
+.dot {
+  width: 7px;
+  height: 7px;
+  background: var(--text-muted);
+  border-radius: 50%;
+  animation: bounce 1.2s infinite;
+}
+
+.dot:nth-child(2) { animation-delay: 0.2s; }
+.dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes bounce {
+  0%, 60%, 100% { transform: translateY(0); }
+  30% { transform: translateY(-5px); }
+}
+
+.assistant-chat-error {
+  padding: 0.4rem 1rem;
+  font-size: 0.82rem;
+  color: var(--error, #d32f2f);
+  background: #fff1f1;
+  margin: 0;
+  border-top: 1px solid #fcc;
+}
+
+.assistant-chat-input-row {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--border);
+  background: var(--surface-raised);
+}
+
+.assistant-chat-input {
+  flex: 1;
+  resize: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  font-family: inherit;
+  background: var(--surface);
+  color: var(--text);
+}
+
+.assistant-chat-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.assistant-chat-send {
+  align-self: flex-end;
+}


### PR DESCRIPTION
## Phase 6 — Meeting Organizer Assistant

Implements the AI-assisted organizer workflow described in the pivot plan.

### What is added

**Backend**
- `src/assistant_actions.py` — `PendingAction` dataclass with Firestore persistence (10-min TTL), builder and executor functions for four action types:
  - `create_series` — creates a new recurring Series
  - `reschedule_occurrence` — reschedules a single Occurrence
  - `draft_material` — returns a drafted agenda/notes/announcement
  - `generate_reminder_text` — returns shareable reminder copy
- `src/assistant.py` — Gemini JSON-mode intent classification, action proposal building, streaming SSE generator (`run_assistant_stream`)
- New endpoints in `api_v2.py`:
  - `POST /v2/workspaces/{id}/assistant` — SSE stream of assistant events
  - `POST /v2/assistant/actions/{id}/confirm` — execute a pending action
  - `POST /v2/assistant/actions/{id}/cancel` — discard a pending action

**Frontend**
- `web/src/AssistantChat.tsx` — streaming chat component that renders SSE events, shows confirm/cancel buttons for proposed actions
- `WorkspaceView.tsx` — "AI Assistant" collapsible section
- `web/src/api.ts` — `sendAssistantMessage`, `confirmAssistantAction`, `cancelAssistantAction`
- `web/src/styles.css` — assistant-chat component styles

**Tests**
- `tests/test_assistant.py` — 20 unit tests covering: PendingAction serialization round-trips, all four builder functions, all four executor functions (Firestore and external calls mocked), Firestore helper methods

### Design decisions
- Actions stored in `pending_assistant_actions` Firestore collection with a 10-minute software TTL checked on read
- Gemini called once per message in JSON mode (structured output) — response is emitted as a single `text_chunk` SSE event; the streaming envelope is preserved for future upgrade to true streaming
- State-changing actions (create_series, reschedule_occurrence) require explicit user confirmation before any write; read-only/generative actions (draft_material, generate_reminder_text) also go through the confirm flow for auditability
- Only organizer/teacher roles can reach the assistant endpoint