### PR TITLE
Unify design across Flutter and web apps (#111)

### DIFF
--- a/flutter_app/lib/app/theme.dart
+++ b/flutter_app/lib/app/theme.dart
@@ -1,13 +1,51 @@
 import 'package:flutter/material.dart';
 
 class AppTheme {
-  static ThemeData get light => ThemeData(
-        useMaterial3: true,
-        colorSchemeSeed: Colors.indigo,
-        brightness: Brightness.light,
-        inputDecorationTheme: const InputDecorationTheme(
-          border: OutlineInputBorder(),
-          contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+  static ThemeData get light {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: Colors.indigo,
+      brightness: Brightness.light,
+    );
+
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: colorScheme,
+      inputDecorationTheme: InputDecorationTheme(
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
         ),
-      );
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        isDense: true,
+      ),
+      appBarTheme: AppBarTheme(
+        centerTitle: false,
+        backgroundColor: colorScheme.surface,
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+        scrolledUnderElevation: 1,
+      ),
+      cardTheme: CardThemeData(
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: BorderSide(color: colorScheme.outlineVariant.withValues(alpha: 0.5)),
+        ),
+        margin: EdgeInsets.zero,
+      ),
+      dividerTheme: const DividerThemeData(space: 1, thickness: 1),
+      listTileTheme: const ListTileThemeData(
+        contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+        visualDensity: VisualDensity.compact,
+      ),
+      chipTheme: ChipThemeData(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+        ),
+        side: BorderSide.none,
+        labelPadding: const EdgeInsets.symmetric(horizontal: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 0),
+      ),
+    );
+  }
 }

--- a/flutter_app/lib/features/auth/sign_in_screen.dart
+++ b/flutter_app/lib/features/auth/sign_in_screen.dart
@@ -32,6 +32,7 @@ class _SignInScreenState extends State<SignInScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     return Scaffold(
       body: Center(
         child: Padding(
@@ -39,25 +40,44 @@ class _SignInScreenState extends State<SignInScreen> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(Icons.event_note,
-                  size: 64, color: Theme.of(context).colorScheme.primary),
+              Container(
+                width: 72,
+                height: 72,
+                decoration: BoxDecoration(
+                  color: cs.primaryContainer,
+                  borderRadius: BorderRadius.circular(18),
+                ),
+                child: Icon(Icons.event_note,
+                    size: 36, color: cs.onPrimaryContainer),
+              ),
               const SizedBox(height: 16),
               Text('Event Ledger',
-                  style: Theme.of(context).textTheme.headlineMedium),
+                  style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                      fontWeight: FontWeight.w700)),
+              const SizedBox(height: 4),
+              Text('Organize your recurring schedules',
+                  style: TextStyle(
+                      color: cs.onSurfaceVariant, fontSize: 14)),
               const SizedBox(height: 32),
               if (_loading)
                 const CircularProgressIndicator()
               else
-                FilledButton.icon(
-                  onPressed: _signIn,
-                  icon: const Icon(Icons.login),
-                  label: const Text('Sign in with Google'),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _signIn,
+                    icon: const Icon(Icons.login),
+                    label: const Text('Sign in with Google'),
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size.fromHeight(48),
+                    ),
+                  ),
                 ),
               if (_error != null) ...[
                 const SizedBox(height: 16),
                 Text(_error!,
-                    style: TextStyle(
-                        color: Theme.of(context).colorScheme.error)),
+                    style: TextStyle(color: cs.error),
+                    textAlign: TextAlign.center),
               ],
             ],
           ),

--- a/flutter_app/lib/features/dashboard/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/dashboard_screen.dart
@@ -83,6 +83,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
         actions: [
           IconButton(
             icon: const Icon(Icons.logout),
+            tooltip: 'Sign out',
             onPressed: () => context.read<AuthService>().signOut(),
           ),
         ],
@@ -113,19 +114,96 @@ class _DashboardScreenState extends State<DashboardScreen> {
     }
     final workspaces = _workspaces ?? [];
     if (workspaces.isEmpty) {
-      return const Center(child: Text('No workspaces yet. Tap + to create one.'));
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.workspaces_outlined,
+                size: 48, color: Theme.of(context).colorScheme.onSurfaceVariant),
+            const SizedBox(height: 12),
+            Text('No workspaces yet',
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 4),
+            Text('Tap + to create one',
+                style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant)),
+          ],
+        ),
+      );
     }
     return RefreshIndicator(
       onRefresh: _load,
-      child: ListView.builder(
+      child: ListView.separated(
+        padding: const EdgeInsets.fromLTRB(12, 8, 12, 80),
         itemCount: workspaces.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 8),
         itemBuilder: (context, index) {
           final ws = workspaces[index];
-          return ListTile(
-            title: Text(ws.title),
-            subtitle: Text(ws.timezone),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => context.push('/workspaces/${ws.workspaceId}'),
+          final memberCount = ws.memberRoles.length;
+          final colors = [
+            Colors.indigo,
+            Colors.teal,
+            Colors.deepOrange,
+            Colors.purple,
+            Colors.blue,
+          ];
+          final color = colors[index % colors.length];
+          return Card(
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(
+              onTap: () => context.push('/workspaces/${ws.workspaceId}'),
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Row(
+                  children: [
+                    CircleAvatar(
+                      backgroundColor: color.withValues(alpha: 0.12),
+                      radius: 22,
+                      child: Text(
+                        ws.title.isNotEmpty ? ws.title[0].toUpperCase() : '?',
+                        style: TextStyle(
+                          color: color,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 18,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 14),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(ws.title,
+                              style: const TextStyle(
+                                  fontWeight: FontWeight.w600, fontSize: 15)),
+                          const SizedBox(height: 2),
+                          Row(
+                            children: [
+                              Icon(Icons.public, size: 13,
+                                  color: Theme.of(context).colorScheme.onSurfaceVariant),
+                              const SizedBox(width: 4),
+                              Text(ws.timezone,
+                                  style: TextStyle(
+                                      fontSize: 12,
+                                      color: Theme.of(context).colorScheme.onSurfaceVariant)),
+                              const SizedBox(width: 12),
+                              Icon(Icons.people_outline, size: 13,
+                                  color: Theme.of(context).colorScheme.onSurfaceVariant),
+                              const SizedBox(width: 4),
+                              Text('$memberCount',
+                                  style: TextStyle(
+                                      fontSize: 12,
+                                      color: Theme.of(context).colorScheme.onSurfaceVariant)),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    Icon(Icons.chevron_right,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant),
+                  ],
+                ),
+              ),
+            ),
           );
         },
       ),

--- a/flutter_app/lib/features/occurrence/occurrence_screen.dart
+++ b/flutter_app/lib/features/occurrence/occurrence_screen.dart
@@ -229,13 +229,14 @@ class _OccurrenceScreenState extends State<OccurrenceScreen> {
 
     final occ = _occurrence!;
     final series = _series!;
+    final cs = Theme.of(context).colorScheme;
     final dt = occ.scheduledDateTime.toLocal();
-    final formatted = DateFormat('EEEE, MMM d, yyyy  HH:mm').format(dt);
     final effectiveLocation = occ.effectiveLocation ?? series.defaultLocation;
     final effectiveLink =
         occ.effectiveOnlineLink ?? series.defaultOnlineLink;
     final duration =
         occ.overrides?.durationMinutes ?? series.defaultDurationMinutes;
+    final statusColor = _statusColorFor(occ.status);
 
     return Scaffold(
       appBar: AppBar(
@@ -251,20 +252,68 @@ class _OccurrenceScreenState extends State<OccurrenceScreen> {
       body: RefreshIndicator(
         onRefresh: _load,
         child: ListView(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.fromLTRB(12, 4, 12, 24),
           children: [
-            // Date & time
+            // Date hero card
             Card(
               child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+                padding: const EdgeInsets.all(14),
+                child: Row(
                   children: [
-                    Text(formatted,
-                        style: Theme.of(context).textTheme.titleMedium),
-                    if (duration != null) Text('Duration: $duration min'),
-                    const SizedBox(height: 8),
-                    _statusChip(occ.status),
+                    Container(
+                      width: 52,
+                      height: 52,
+                      decoration: BoxDecoration(
+                        color: cs.primaryContainer,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(DateFormat('d').format(dt),
+                              style: TextStyle(
+                                  fontWeight: FontWeight.w700,
+                                  fontSize: 20,
+                                  color: cs.onPrimaryContainer)),
+                          Text(DateFormat('MMM').format(dt),
+                              style: TextStyle(
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w500,
+                                  color: cs.onPrimaryContainer)),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 14),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(DateFormat('EEEE').format(dt),
+                              style: const TextStyle(
+                                  fontWeight: FontWeight.w600, fontSize: 15)),
+                          Text(DateFormat('MMM d, yyyy  HH:mm').format(dt),
+                              style: TextStyle(
+                                  fontSize: 13, color: cs.onSurfaceVariant)),
+                          if (duration != null)
+                            Text('$duration min',
+                                style: TextStyle(
+                                    fontSize: 12, color: cs.onSurfaceVariant)),
+                        ],
+                      ),
+                    ),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 10, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: statusColor.withValues(alpha: 0.12),
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                      child: Text(occ.status,
+                          style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w500,
+                              color: statusColor)),
+                    ),
                   ],
                 ),
               ),
@@ -274,40 +323,29 @@ class _OccurrenceScreenState extends State<OccurrenceScreen> {
             if (effectiveLocation != null || effectiveLink != null) ...[
               const SizedBox(height: 8),
               Card(
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      if (effectiveLocation != null)
-                        Row(
-                          children: [
-                            const Icon(Icons.location_on, size: 18),
-                            const SizedBox(width: 8),
-                            Expanded(child: Text(effectiveLocation)),
-                          ],
-                        ),
-                      if (effectiveLink != null) ...[
-                        const SizedBox(height: 4),
-                        InkWell(
-                          onTap: () => launchUrl(Uri.parse(effectiveLink)),
-                          child: Row(
-                            children: [
-                              const Icon(Icons.link, size: 18),
-                              const SizedBox(width: 8),
-                              Expanded(
-                                child: Text(effectiveLink,
-                                    style: TextStyle(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .primary)),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
+                child: Column(
+                  children: [
+                    if (effectiveLocation != null)
+                      ListTile(
+                        leading: Icon(Icons.location_on_outlined, size: 20,
+                            color: cs.onSurfaceVariant),
+                        title: Text(effectiveLocation,
+                            style: const TextStyle(fontSize: 14)),
+                      ),
+                    if (effectiveLocation != null && effectiveLink != null)
+                      Divider(height: 1, indent: 56,
+                          color: cs.outlineVariant.withValues(alpha: 0.4)),
+                    if (effectiveLink != null)
+                      ListTile(
+                        leading: Icon(Icons.videocam_outlined, size: 20,
+                            color: cs.primary),
+                        title: Text('Join online meeting',
+                            style: TextStyle(fontSize: 14, color: cs.primary)),
+                        trailing: Icon(Icons.open_in_new, size: 16,
+                            color: cs.onSurfaceVariant),
+                        onTap: () => launchUrl(Uri.parse(effectiveLink)),
+                      ),
+                  ],
                 ),
               ),
             ],
@@ -318,91 +356,146 @@ class _OccurrenceScreenState extends State<OccurrenceScreen> {
               const SizedBox(height: 8),
               Card(
                 child: Padding(
-                  padding: const EdgeInsets.all(16),
+                  padding: const EdgeInsets.all(14),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text('Notes',
-                          style: Theme.of(context).textTheme.titleSmall),
-                      const SizedBox(height: 4),
-                      Text(occ.effectiveNotes!),
+                      Row(
+                        children: [
+                          Icon(Icons.notes, size: 16, color: cs.onSurfaceVariant),
+                          const SizedBox(width: 8),
+                          Text('Notes',
+                              style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w600,
+                                  color: cs.onSurfaceVariant)),
+                        ],
+                      ),
+                      const SizedBox(height: 6),
+                      Text(occ.effectiveNotes!,
+                          style: const TextStyle(fontSize: 14)),
                     ],
                   ),
                 ),
               ),
             ],
 
-            // Organizer/teacher controls
-            if (_canManage) ...[
-              const SizedBox(height: 16),
-              Text('Manage',
-                  style: Theme.of(context).textTheme.titleMedium),
-              const SizedBox(height: 8),
-              // Status controls
-              Wrap(
-                spacing: 8,
-                children: [
-                  if (occ.status == 'scheduled') ...[
-                    FilledButton(
-                        onPressed: () => _updateStatus('completed'),
-                        child: const Text('Complete')),
-                    OutlinedButton(
-                        onPressed: () => _updateStatus('cancelled'),
-                        child: const Text('Cancel')),
-                  ],
-                ],
-              ),
-              const SizedBox(height: 8),
-              SwitchListTile(
-                title: const Text('Enable Check-in'),
-                value: occ.enableCheckIn,
-                onChanged: (v) => _toggleCheckIn(v),
-              ),
-            ],
-
-            // Self check-in (participant)
+            // Check-in section
             if (occ.enableCheckIn) ...[
-              const SizedBox(height: 16),
-              if (_myCheckIn == null ||
-                  _myCheckIn!.status != 'confirmed')
-                FilledButton.icon(
-                  onPressed: _checkIn,
-                  icon: const Icon(Icons.check),
-                  label: const Text('Check In'),
+              const SizedBox(height: 12),
+              if (_myCheckIn == null || _myCheckIn!.status != 'confirmed')
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _checkIn,
+                    icon: const Icon(Icons.check_circle_outline),
+                    label: const Text('Check In'),
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size.fromHeight(44),
+                    ),
+                  ),
                 )
               else
-                Row(
+                Card(
+                  color: Colors.green.shade50,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 14, vertical: 10),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.check_circle,
+                            color: Colors.green, size: 22),
+                        const SizedBox(width: 10),
+                        const Expanded(
+                          child: Text('Checked in',
+                              style: TextStyle(
+                                  fontWeight: FontWeight.w500,
+                                  color: Colors.green)),
+                        ),
+                        TextButton(
+                            onPressed: _undoCheckIn,
+                            child: const Text('Undo')),
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+
+            // Manager controls
+            if (_canManage) ...[
+              const SizedBox(height: 16),
+              _sectionLabel('Manage', cs),
+              const SizedBox(height: 6),
+              Card(
+                child: Column(
                   children: [
-                    const Icon(Icons.check_circle, color: Colors.green),
-                    const SizedBox(width: 8),
-                    const Text('Checked in'),
-                    const Spacer(),
-                    TextButton(
-                        onPressed: _undoCheckIn,
-                        child: const Text('Undo')),
+                    // Status controls
+                    if (occ.status == 'scheduled')
+                      Padding(
+                        padding: const EdgeInsets.all(12),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: FilledButton(
+                                onPressed: () => _updateStatus('completed'),
+                                child: const Text('Complete'),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: OutlinedButton(
+                                onPressed: () => _updateStatus('cancelled'),
+                                child: const Text('Cancel'),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    SwitchListTile(
+                      title: const Text('Enable Check-in',
+                          style: TextStyle(fontSize: 14)),
+                      value: occ.enableCheckIn,
+                      onChanged: (v) => _toggleCheckIn(v),
+                    ),
                   ],
                 ),
+              ),
             ],
 
             // All check-ins (organizer/teacher)
-            if (_canManage && _allCheckIns != null) ...[
+            if (_canManage && _allCheckIns != null && _allCheckIns!.isNotEmpty) ...[
               const SizedBox(height: 16),
-              Text('Check-ins (${_allCheckIns!.length})',
-                  style: Theme.of(context).textTheme.titleMedium),
-              if (_allCheckIns!.isEmpty)
-                const Padding(
-                  padding: EdgeInsets.all(8),
-                  child: Text('No check-ins yet.'),
+              _sectionLabel('Check-ins (${_allCheckIns!.length})', cs),
+              const SizedBox(height: 6),
+              Card(
+                clipBehavior: Clip.antiAlias,
+                child: Column(
+                  children: _allCheckIns!.asMap().entries.map((entry) {
+                    final ci = entry.value;
+                    final isLast = entry.key == _allCheckIns!.length - 1;
+                    return Column(
+                      children: [
+                        ListTile(
+                          leading: _checkInIcon(ci.status),
+                          title: Text(
+                              ci.displayName ?? ci.userId.substring(0, 8),
+                              style: const TextStyle(fontSize: 14)),
+                          subtitle: ci.note != null
+                              ? Text(ci.note!,
+                                  style: const TextStyle(fontSize: 12))
+                              : null,
+                          trailing: Text(ci.status,
+                              style: TextStyle(
+                                  fontSize: 12, color: cs.onSurfaceVariant)),
+                        ),
+                        if (!isLast)
+                          Divider(height: 1, indent: 56,
+                              color: cs.outlineVariant.withValues(alpha: 0.4)),
+                      ],
+                    );
+                  }).toList(),
                 ),
-              ..._allCheckIns!.map((ci) => ListTile(
-                    dense: true,
-                    leading: _checkInIcon(ci.status),
-                    title:
-                        Text(ci.displayName ?? ci.userId.substring(0, 8)),
-                    subtitle: ci.note != null ? Text(ci.note!) : null,
-                    trailing: Text(ci.status,
-                        style: const TextStyle(fontSize: 12)),
-                  )),
+              ),
             ],
           ],
         ),
@@ -410,19 +503,27 @@ class _OccurrenceScreenState extends State<OccurrenceScreen> {
     );
   }
 
-  Widget _statusChip(String status) {
-    final color = switch (status) {
+  Widget _sectionLabel(String text, ColorScheme cs) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Text(text,
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.5,
+            color: cs.onSurfaceVariant,
+          )),
+    );
+  }
+
+  Color _statusColorFor(String status) {
+    return switch (status) {
       'scheduled' => Colors.blue,
       'completed' => Colors.green,
       'cancelled' => Colors.grey,
       'rescheduled' => Colors.orange,
       _ => Colors.grey,
     };
-    return Chip(
-      label: Text(status),
-      backgroundColor: color.withValues(alpha: 0.15),
-      side: BorderSide.none,
-    );
   }
 
   Widget _checkInIcon(String status) {

--- a/flutter_app/lib/features/series/series_screen.dart
+++ b/flutter_app/lib/features/series/series_screen.dart
@@ -164,6 +164,7 @@ class _SeriesScreenState extends State<SeriesScreen> {
 
     final series = _series!;
     final occs = _occurrences ?? [];
+    final cs = Theme.of(context).colorScheme;
     final now = DateTime.now().toUtc();
     final upcoming =
         occs.where((o) => o.scheduledDateTime.isAfter(now) && o.status == 'scheduled').toList()
@@ -183,30 +184,29 @@ class _SeriesScreenState extends State<SeriesScreen> {
       body: RefreshIndicator(
         onRefresh: _load,
         child: ListView(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.fromLTRB(12, 4, 12, 24),
           children: [
             // Series info card
             Card(
               child: Padding(
-                padding: const EdgeInsets.all(16),
+                padding: const EdgeInsets.all(14),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(series.scheduleDescription,
-                        style: Theme.of(context).textTheme.titleSmall),
+                    _infoRow(Icons.schedule, series.scheduleDescription, cs),
                     if (series.defaultTime != null)
-                      Text('Time: ${series.defaultTime}'),
+                      _infoRow(Icons.access_time, 'Time: ${series.defaultTime}', cs),
                     if (series.defaultDurationMinutes != null)
-                      Text('Duration: ${series.defaultDurationMinutes} min'),
+                      _infoRow(Icons.timelapse, '${series.defaultDurationMinutes} min', cs),
                     if (series.defaultLocation != null)
-                      Text('Location: ${series.defaultLocation}'),
+                      _infoRow(Icons.location_on_outlined, series.defaultLocation!, cs),
                     if (series.defaultOnlineLink != null)
-                      Text('Link: ${series.defaultOnlineLink}'),
-                    Text('Location mode: ${series.locationType}'),
+                      _infoRow(Icons.link, series.defaultOnlineLink!, cs),
                     if (series.description != null &&
                         series.description!.isNotEmpty) ...[
                       const SizedBox(height: 8),
-                      Text(series.description!),
+                      Text(series.description!,
+                          style: TextStyle(fontSize: 13, color: cs.onSurfaceVariant)),
                     ],
                   ],
                 ),
@@ -216,40 +216,59 @@ class _SeriesScreenState extends State<SeriesScreen> {
             // Next meeting
             if (upcoming.isNotEmpty) ...[
               const SizedBox(height: 16),
-              Text('Next Meeting',
-                  style: Theme.of(context).textTheme.titleMedium),
-              _occurrenceTile(upcoming.first),
+              _sectionLabel('Next Meeting', cs),
+              const SizedBox(height: 6),
+              _meetingCard(upcoming.first, cs, isNext: true),
             ],
 
             // Last meeting
             if (past.isNotEmpty) ...[
-              const SizedBox(height: 16),
-              Text('Last Meeting',
-                  style: Theme.of(context).textTheme.titleMedium),
-              _occurrenceTile(past.first),
+              const SizedBox(height: 12),
+              _sectionLabel('Last Meeting', cs),
+              const SizedBox(height: 6),
+              _meetingCard(past.first, cs, isPast: true),
             ],
 
             // Generate button
             if (_canManage) ...[
-              const SizedBox(height: 16),
+              const SizedBox(height: 12),
               OutlinedButton.icon(
                 onPressed: _generateOccurrences,
-                icon: const Icon(Icons.add_circle_outline),
-                label: const Text('Generate Occurrences (next 90 days)'),
+                icon: const Icon(Icons.add_circle_outline, size: 18),
+                label: const Text('Generate next 90 days'),
+                style: OutlinedButton.styleFrom(
+                  minimumSize: const Size.fromHeight(40),
+                ),
               ),
             ],
 
             // Upcoming list
             if (upcoming.length > 1) ...[
               const SizedBox(height: 16),
-              Text('Upcoming',
-                  style: Theme.of(context).textTheme.titleMedium),
-              ...upcoming.skip(1).map(_occurrenceTile),
+              _sectionLabel('Upcoming', cs),
+              const SizedBox(height: 6),
+              Card(
+                clipBehavior: Clip.antiAlias,
+                child: Column(
+                  children: upcoming.skip(1).take(10).toList().asMap().entries.map((entry) {
+                    final occ = entry.value;
+                    final isLast = entry.key == (upcoming.length - 2).clamp(0, 9);
+                    return Column(
+                      children: [
+                        _occurrenceListItem(occ, cs),
+                        if (!isLast)
+                          Divider(height: 1, indent: 16, endIndent: 16,
+                              color: cs.outlineVariant.withValues(alpha: 0.4)),
+                      ],
+                    );
+                  }).toList(),
+                ),
+              ),
             ],
 
             // Check-in report
             if (_canManage) ...[
-              const SizedBox(height: 24),
+              const SizedBox(height: 16),
               CheckInReportWidget(seriesId: widget.seriesId),
             ],
           ],
@@ -258,32 +277,179 @@ class _SeriesScreenState extends State<SeriesScreen> {
     );
   }
 
-  Widget _occurrenceTile(Occurrence occ) {
-    final dt = occ.scheduledDateTime.toLocal();
-    final formatted = DateFormat('E, MMM d, yyyy  HH:mm').format(dt);
-    return ListTile(
-      title: Text(occ.effectiveTitle.isNotEmpty
-          ? occ.effectiveTitle
-          : formatted),
-      subtitle: occ.effectiveTitle.isNotEmpty ? Text(formatted) : null,
-      trailing: _statusChip(occ.status),
-      onTap: () => context.push('/occurrences/${occ.occurrenceId}'),
+  Widget _infoRow(IconData icon, String text, ColorScheme cs) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        children: [
+          Icon(icon, size: 16, color: cs.onSurfaceVariant),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(text,
+                style: TextStyle(fontSize: 13, color: cs.onSurfaceVariant),
+                overflow: TextOverflow.ellipsis),
+          ),
+        ],
+      ),
     );
   }
 
-  Widget _statusChip(String status) {
-    final color = switch (status) {
+  Widget _sectionLabel(String text, ColorScheme cs) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Text(text,
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.5,
+            color: cs.onSurfaceVariant,
+          )),
+    );
+  }
+
+  Widget _meetingCard(Occurrence occ, ColorScheme cs,
+      {bool isNext = false, bool isPast = false}) {
+    final dt = occ.scheduledDateTime.toLocal();
+    final dateStr = DateFormat('E, MMM d').format(dt);
+    final timeStr = DateFormat('HH:mm').format(dt);
+    final statusColor = _statusColor(occ.status);
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () => context.push('/occurrences/${occ.occurrenceId}'),
+        child: Padding(
+          padding: const EdgeInsets.all(14),
+          child: Row(
+            children: [
+              Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color: isNext
+                      ? cs.primaryContainer
+                      : cs.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(DateFormat('d').format(dt),
+                        style: TextStyle(
+                            fontWeight: FontWeight.w700,
+                            fontSize: 16,
+                            color: isNext ? cs.onPrimaryContainer : cs.onSurface)),
+                    Text(DateFormat('MMM').format(dt),
+                        style: TextStyle(
+                            fontSize: 10,
+                            fontWeight: FontWeight.w500,
+                            color: isNext ? cs.onPrimaryContainer : cs.onSurfaceVariant)),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      occ.effectiveTitle.isNotEmpty
+                          ? occ.effectiveTitle
+                          : dateStr,
+                      style: TextStyle(
+                        fontWeight: FontWeight.w500,
+                        fontSize: 14,
+                        color: isPast ? cs.onSurfaceVariant : cs.onSurface,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      occ.effectiveTitle.isNotEmpty ? '$dateStr  $timeStr' : timeStr,
+                      style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant),
+                    ),
+                    if (occ.effectiveLocation != null) ...[
+                      const SizedBox(height: 2),
+                      Row(
+                        children: [
+                          Icon(Icons.location_on_outlined, size: 12,
+                              color: cs.onSurfaceVariant),
+                          const SizedBox(width: 3),
+                          Expanded(
+                            child: Text(occ.effectiveLocation!,
+                                style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant),
+                                overflow: TextOverflow.ellipsis),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                decoration: BoxDecoration(
+                  color: statusColor.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(occ.status,
+                    style: TextStyle(fontSize: 11, color: statusColor,
+                        fontWeight: FontWeight.w500)),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _occurrenceListItem(Occurrence occ, ColorScheme cs) {
+    final dt = occ.scheduledDateTime.toLocal();
+    final dateStr = DateFormat('E, MMM d').format(dt);
+    final timeStr = DateFormat('HH:mm').format(dt);
+
+    return InkWell(
+      onTap: () => context.push('/occurrences/${occ.occurrenceId}'),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 28,
+              child: Text(DateFormat('d').format(dt),
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 15,
+                      color: cs.onSurface)),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('$dateStr  $timeStr',
+                      style: TextStyle(fontSize: 13, color: cs.onSurface)),
+                  if (occ.effectiveLocation != null)
+                    Text(occ.effectiveLocation!,
+                        style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant),
+                        overflow: TextOverflow.ellipsis),
+                ],
+              ),
+            ),
+            Icon(Icons.chevron_right, size: 18, color: cs.onSurfaceVariant),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _statusColor(String status) {
+    return switch (status) {
       'scheduled' => Colors.blue,
       'completed' => Colors.green,
       'cancelled' => Colors.grey,
       'rescheduled' => Colors.orange,
       _ => Colors.grey,
     };
-    return Chip(
-      label: Text(status, style: const TextStyle(fontSize: 11)),
-      backgroundColor: color.withValues(alpha: 0.15),
-      side: BorderSide.none,
-      visualDensity: VisualDensity.compact,
-    );
   }
 }

--- a/flutter_app/lib/features/workspace/workspace_screen.dart
+++ b/flutter_app/lib/features/workspace/workspace_screen.dart
@@ -159,6 +159,7 @@ class _WorkspaceScreenState extends State<WorkspaceScreen> {
 
     final ws = _workspace!;
     final series = _series ?? [];
+    final cs = Theme.of(context).colorScheme;
 
     return Scaffold(
       appBar: AppBar(
@@ -176,76 +177,239 @@ class _WorkspaceScreenState extends State<WorkspaceScreen> {
       body: RefreshIndicator(
         onRefresh: _load,
         child: ListView(
+          padding: const EdgeInsets.fromLTRB(12, 4, 12, 80),
           children: [
             // Workspace info
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text('Timezone: ${ws.timezone}',
-                      style: Theme.of(context).textTheme.bodyMedium),
-                  if (ws.description != null && ws.description!.isNotEmpty)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 4),
-                      child: Text(ws.description!),
-                    ),
-                ],
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Row(
+                  children: [
+                    Icon(Icons.public, size: 16, color: cs.onSurfaceVariant),
+                    const SizedBox(width: 8),
+                    Text(ws.timezone,
+                        style: TextStyle(fontSize: 13, color: cs.onSurfaceVariant)),
+                    const Spacer(),
+                    Icon(Icons.people_outline, size: 16, color: cs.onSurfaceVariant),
+                    const SizedBox(width: 6),
+                    Text('${ws.memberRoles.length} members',
+                        style: TextStyle(fontSize: 13, color: cs.onSurfaceVariant)),
+                  ],
+                ),
               ),
             ),
+            if (ws.description != null && ws.description!.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(14),
+                  child: Text(ws.description!,
+                      style: TextStyle(fontSize: 13, color: cs.onSurfaceVariant)),
+                ),
+              ),
+            ],
 
             // Members section
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                children: [
-                  Text('Members',
-                      style: Theme.of(context).textTheme.titleMedium),
-                  const Spacer(),
-                  if (_isOrganizer(ws))
-                    TextButton.icon(
+            const SizedBox(height: 16),
+            _SectionHeader(
+              icon: Icons.people_outline,
+              title: 'Members',
+              trailing: _isOrganizer(ws)
+                  ? TextButton.icon(
                       onPressed: _createInvite,
-                      icon: const Icon(Icons.person_add, size: 18),
+                      icon: const Icon(Icons.person_add, size: 16),
                       label: const Text('Invite'),
-                    ),
+                      style: TextButton.styleFrom(
+                        visualDensity: VisualDensity.compact,
+                        textStyle: const TextStyle(fontSize: 13),
+                      ),
+                    )
+                  : null,
+            ),
+            const SizedBox(height: 6),
+            Card(
+              clipBehavior: Clip.antiAlias,
+              child: Column(
+                children: [
+                  ...ws.memberRoles.entries.toList().asMap().entries.map((entry) {
+                    final e = entry.value;
+                    final isLast = entry.key == ws.memberRoles.length - 1;
+                    final profile = ws.memberProfiles[e.key];
+                    final name = profile?['display_name'] ?? e.key.substring(0, 8);
+                    final isMe = e.key == _uid;
+                    return Column(
+                      children: [
+                        ListTile(
+                          leading: CircleAvatar(
+                            radius: 16,
+                            backgroundColor: cs.primaryContainer,
+                            child: Text(
+                              (name as String).isNotEmpty ? name[0].toUpperCase() : '?',
+                              style: TextStyle(
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w600,
+                                  color: cs.onPrimaryContainer),
+                            ),
+                          ),
+                          title: Text(isMe ? '$name (You)' : name,
+                              style: const TextStyle(fontSize: 14)),
+                          trailing: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 2),
+                            decoration: BoxDecoration(
+                              color: e.value == 'organizer'
+                                  ? cs.primaryContainer
+                                  : cs.surfaceContainerHighest,
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: Text(e.value,
+                                style: TextStyle(
+                                    fontSize: 11,
+                                    color: e.value == 'organizer'
+                                        ? cs.onPrimaryContainer
+                                        : cs.onSurfaceVariant)),
+                          ),
+                        ),
+                        if (!isLast)
+                          Divider(height: 1, indent: 56,
+                              color: cs.outlineVariant.withValues(alpha: 0.4)),
+                      ],
+                    );
+                  }),
                 ],
               ),
             ),
-            ...ws.memberRoles.entries.map((e) {
-              final profile = ws.memberProfiles[e.key];
-              final name = profile?['display_name'] ?? e.key.substring(0, 8);
-              return ListTile(
-                dense: true,
-                leading: const Icon(Icons.person, size: 20),
-                title: Text(name),
-                trailing: Chip(
-                  label: Text(e.value, style: const TextStyle(fontSize: 11)),
-                  visualDensity: VisualDensity.compact,
-                ),
-              );
-            }),
-
-            const Divider(),
 
             // Series section
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Text('Series',
-                  style: Theme.of(context).textTheme.titleMedium),
-            ),
+            const SizedBox(height: 16),
+            _SectionHeader(icon: Icons.event_repeat, title: 'Series'),
+            const SizedBox(height: 6),
             if (series.isEmpty)
-              const Padding(
-                padding: EdgeInsets.all(16),
-                child: Text('No series yet.'),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(20),
+                  child: Center(
+                    child: Column(
+                      children: [
+                        Icon(Icons.event_note, size: 32, color: cs.onSurfaceVariant),
+                        const SizedBox(height: 8),
+                        Text('No series yet',
+                            style: TextStyle(color: cs.onSurfaceVariant, fontSize: 13)),
+                      ],
+                    ),
+                  ),
+                ),
               ),
-            ...series.map((s) => ListTile(
-                  title: Text(s.title),
-                  subtitle: Text(s.scheduleDescription),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () => context.push('/series/${s.seriesId}'),
+            ...series.map((s) => Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: _seriesCard(s, cs),
                 )),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _seriesCard(Series s, ColorScheme cs) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () => context.push('/series/${s.seriesId}'),
+        child: Padding(
+          padding: const EdgeInsets.all(14),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(s.title,
+                        style: const TextStyle(
+                            fontWeight: FontWeight.w600, fontSize: 15)),
+                  ),
+                  Icon(Icons.chevron_right, size: 20, color: cs.onSurfaceVariant),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Row(
+                children: [
+                  Icon(Icons.schedule, size: 14, color: cs.onSurfaceVariant),
+                  const SizedBox(width: 4),
+                  Text(s.scheduleDescription,
+                      style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant)),
+                  if (s.defaultTime != null) ...[
+                    Text(' at ${s.defaultTime}',
+                        style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant)),
+                  ],
+                ],
+              ),
+              if (s.defaultLocation != null || s.defaultOnlineLink != null) ...[
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    Icon(
+                      s.defaultLocation != null
+                          ? Icons.location_on_outlined
+                          : Icons.link,
+                      size: 14,
+                      color: cs.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: 4),
+                    Expanded(
+                      child: Text(
+                        s.defaultLocation ?? 'Online',
+                        style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+              if (s.description != null && s.description!.isNotEmpty) ...[
+                const SizedBox(height: 6),
+                Text(s.description!,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(fontSize: 13, color: cs.onSurfaceVariant)),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final Widget? trailing;
+
+  const _SectionHeader({
+    required this.icon,
+    required this.title,
+    this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Row(
+        children: [
+          Icon(icon, size: 16, color: cs.onSurfaceVariant),
+          const SizedBox(width: 6),
+          Text(title,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.5,
+                color: cs.onSurfaceVariant,
+              )),
+          const Spacer(),
+          if (trailing != null) trailing!,
+        ],
       ),
     );
   }

--- a/web/index.html
+++ b/web/index.html
@@ -3,9 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Meeting Assistant</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@600;700&family=DM+Sans:wght@300;400;500&display=swap" rel="stylesheet">
+    <title>Event Ledger</title>
+    <meta name="theme-color" content="#3F51B5" />
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/components/NavBar.tsx
+++ b/web/src/components/NavBar.tsx
@@ -7,7 +7,7 @@ export function NavBar() {
   return (
     <nav className="navbar">
       <Link to="/dashboard" className="navbar-brand">
-        Meeting Assistant
+        Event Ledger
       </Link>
       {user && (
         <div className="navbar-user">

--- a/web/src/routes/AcceptInvite.tsx
+++ b/web/src/routes/AcceptInvite.tsx
@@ -32,28 +32,29 @@ export function AcceptInvite() {
 
   if (error) {
     return (
-      <div className="workspace-view" style={{ textAlign: "center", paddingTop: "4rem" }}>
+      <div className="invite-page">
         <h2>Invite Error</h2>
         <p className="form-error">{error}</p>
-        <button className="btn btn-primary btn-sm" onClick={doAccept}>
-          Retry
-        </button>
-        <button
-          className="btn btn-secondary btn-sm"
-          style={{ marginLeft: "0.5rem" }}
-          onClick={() => navigate("/dashboard")}
-        >
-          Go to Dashboard
-        </button>
+        <div className="invite-actions">
+          <button className="btn btn-primary btn-sm" onClick={doAccept}>
+            Retry
+          </button>
+          <button
+            className="btn btn-secondary btn-sm"
+            onClick={() => navigate("/dashboard")}
+          >
+            Go to Dashboard
+          </button>
+        </div>
       </div>
     );
   }
 
   if (!started) {
     return (
-      <div className="workspace-view" style={{ textAlign: "center", paddingTop: "4rem" }}>
+      <div className="invite-page">
         <h2>You've been invited!</h2>
-        <p style={{ margin: "1rem 0", color: "var(--muted)" }}>Click below to join this workspace.</p>
+        <p>Click below to join this workspace.</p>
         <button className="btn btn-primary" onClick={doAccept}>
           Accept Invite
         </button>

--- a/web/src/routes/Landing.tsx
+++ b/web/src/routes/Landing.tsx
@@ -14,8 +14,8 @@ export function Landing() {
 
   return (
     <div className="landing">
-      <h1>Meeting Assistant</h1>
-      <p>Organize your recurring meetings with ease.</p>
+      <h1>Event Ledger</h1>
+      <p>Organize your recurring schedules with ease.</p>
       <button type="button" onClick={signIn} className="btn btn-primary">
         Sign in with Google
       </button>

--- a/web/src/routes/OccurrenceSummaryPage.tsx
+++ b/web/src/routes/OccurrenceSummaryPage.tsx
@@ -129,7 +129,7 @@ export function OccurrenceSummaryPage() {
       </div>
 
       <div className="summary-footer">
-        <span>Powered by Meeting Assistant</span>
+        <span>Powered by Event Ledger</span>
       </div>
     </div>
   );

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,2098 +1,604 @@
+/* === Design System: Matches Flutter Material 3 (Indigo) === */
+
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --navy: #0f1e35;
-  --navy-mid: #162845;
-  --navy-light: #1e3459;
-  --gold: #c9a84c;
-  --gold-light: #e2c97e;
-  --cream: #f5f0e8;
-  --cream-dark: #ede5d6;
-  --text: #1a1a2e;
-  --muted: #6b7a99;
-  --card-bg: #ffffff;
-  --border: rgba(201, 168, 76, 0.2);
+  --primary: #3F51B5;
+  --primary-light: #5C6BC0;
+  --primary-dark: #303F9F;
+  --on-primary: #ffffff;
+  --surface: #ffffff;
+  --surface-dim: #f5f5f5;
+  --surface-container: #f0f0f3;
+  --on-surface: #1C1B1F;
+  --on-surface-variant: #49454F;
+  --outline: #79747E;
+  --outline-variant: #CAC4D0;
+  --error: #B3261E;
+  --success: #2E7D32;
+  --warning: #E65100;
+  --radius: 12px;
+  --radius-sm: 8px;
+  --radius-xs: 4px;
 }
 
 /* Base */
 body {
-  font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
-  background: var(--cream);
-  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--surface-dim);
+  color: var(--on-surface);
   min-height: 100vh;
-  position: relative;
-}
-
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  background-image:
-    radial-gradient(ellipse at 20% 0%, rgba(201,168,76,0.08) 0%, transparent 60%),
-    radial-gradient(ellipse at 80% 100%, rgba(15,30,53,0.06) 0%, transparent 60%);
-  pointer-events: none;
-  z-index: 0;
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
 }
 
 /* Navbar */
 .navbar {
-  background: var(--navy);
-  padding: 0 1rem;
-  height: 60px;
+  background: var(--primary);
+  padding: 0 12px;
+  height: 56px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   position: sticky;
   top: 0;
   z-index: 100;
-  box-shadow: 0 2px 20px rgba(0,0,0,0.25);
-}
-
-.navbar::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0; right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--gold), transparent);
 }
 
 .navbar-brand {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
   font-size: 1rem;
   font-weight: 600;
-  color: var(--gold-light);
+  color: var(--on-primary);
   text-decoration: none;
-  letter-spacing: 0.04em;
-  transition: opacity 0.2s;
-  white-space: nowrap;
+  letter-spacing: 0.01em;
 }
-.navbar-brand:hover { opacity: 0.8; }
+
+.navbar-brand:hover { opacity: 0.9; }
 
 .navbar-user {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 8px;
 }
 
 .navbar-email {
-  color: rgba(255,255,255,0.5);
+  color: rgba(255,255,255,0.8);
   font-size: 0.8rem;
-  font-weight: 300;
-  letter-spacing: 0.02em;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.navbar .btn-sm {
+  background: rgba(255,255,255,0.15);
+  color: var(--on-primary);
+  border-color: rgba(255,255,255,0.3);
+  font-size: 0.75rem;
+  padding: 4px 10px;
+}
+
+.navbar .btn-sm:hover {
+  background: rgba(255,255,255,0.25);
 }
 
 /* Buttons */
 .btn {
-  padding: 0.35rem 0.9rem;
-  border-radius: 4px;
-  font-family: 'DM Sans', system-ui, sans-serif;
-  font-size: 0.78rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
   font-weight: 500;
+  border: 1px solid transparent;
   cursor: pointer;
-  letter-spacing: 0.03em;
-  transition: all 0.2s;
+  transition: background 0.15s, opacity 0.15s;
+  white-space: nowrap;
+  line-height: 1.4;
 }
 
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
 .btn-primary {
-  background: var(--navy);
-  color: var(--gold-light);
-  border: 1px solid rgba(201,168,76,0.4);
+  background: var(--primary);
+  color: var(--on-primary);
+  border-color: var(--primary);
 }
-.btn-primary:hover { background: var(--navy-light); }
-.btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.btn-primary:hover:not(:disabled) { background: var(--primary-dark); }
 
 .btn-secondary {
   background: transparent;
-  border: 1px solid rgba(201,168,76,0.4);
-  color: var(--gold-light);
+  color: var(--primary);
+  border-color: var(--outline-variant);
 }
-.btn-secondary:hover {
-  background: rgba(201,168,76,0.1);
-  border-color: var(--gold);
-}
-.btn-secondary:disabled { opacity: 0.4; cursor: not-allowed; }
-
-.btn-sm {
-  padding: 0.25rem 0.6rem;
-  font-size: 0.75rem;
-}
-
-/* Layout */
-.main-content {
-  position: relative;
-  z-index: 1;
-  max-width: 720px;
-  margin: 0 auto;
-  padding: 2.5rem 1.5rem 4rem;
-}
-
-/* Animations */
-@keyframes fadeUp {
-  from { opacity: 0; transform: translateY(14px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-/* Loading & errors */
-.loading-screen {
-  text-align: center;
-  padding: 3rem;
-  color: var(--muted);
-  font-style: italic;
-}
-
-.loading {
-  color: var(--muted);
-  font-style: italic;
-  font-size: 0.9rem;
-}
-
-.error { color: #c00; }
-
-.error-container {
-  padding: 2rem;
-  text-align: center;
-}
-
-.placeholder {
-  color: var(--muted);
-  font-style: italic;
-  font-size: 0.9rem;
-}
-
-/* Page header */
-.page-header {
-  margin-bottom: 2.5rem;
-  animation: fadeUp 0.5s ease both;
-}
-
-.page-header-top {
-  display: flex;
-  gap: 1.2rem;
-  margin-bottom: 1.2rem;
-  align-items: center;
-}
-
-.back-link {
-  font-size: 0.78rem;
-  font-weight: 500;
-  color: var(--muted);
-  text-decoration: none;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  transition: color 0.2s;
-}
-.back-link:hover { color: var(--gold); }
-
-.page-header h1 {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
-  font-size: 2rem;
-  font-weight: 600;
-  color: var(--navy);
-  letter-spacing: 0.01em;
-  display: flex;
-  align-items: center;
-  gap: 0.7rem;
-  line-height: 1.1;
-  border-bottom: none;
-  padding-bottom: 0;
-}
-
-/* Badges */
-.badge {
-  font-family: 'DM Sans', system-ui, sans-serif;
-  font-size: 0.65rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 0.2rem 0.55rem;
-  border-radius: 2px;
-  vertical-align: middle;
-  position: relative;
-  top: -2px;
-}
-
-.badge-public {
-  color: var(--gold);
-  border: 1px solid var(--gold);
-  background: transparent;
-}
-
-.badge-personal {
-  color: var(--muted);
-  border: 1px solid var(--muted);
-  background: transparent;
-}
-
-.badge-members {
-  color: var(--navy);
-  border: 1px solid var(--navy);
-  background: rgba(10,30,63,0.08);
-  font-size: 0.6rem;
-}
-
-/* Sections */
-section {
-  margin-bottom: 2.5rem;
-  animation: fadeUp 0.5s ease both;
-}
-
-.section-heading {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
-  font-size: 0.75rem;
-  font-weight: 400;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--muted);
-  margin-bottom: 1rem;
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-}
-.section-heading::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  background: var(--border);
-}
-
-/* Memory list */
-.memory-list {
-  list-style: none;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-}
-
-/* Memory card */
-.memory-card {
-  background: var(--card-bg);
-  border: 1px solid var(--cream-dark);
-  border-radius: 8px;
-  overflow: hidden;
-  transition: box-shadow 0.25s, border-color 0.25s, transform 0.2s;
-}
-.memory-card:hover {
-  box-shadow: 0 4px 24px rgba(15,30,53,0.1);
-  border-color: rgba(201,168,76,0.3);
-  transform: translateY(-1px);
-}
-
-.memory-card details summary {
-  padding: 1rem 1.2rem;
-  cursor: pointer;
-  list-style: none;
-  display: flex;
-  align-items: flex-start;
-  gap: 0.8rem;
-  user-select: none;
-}
-.memory-card details summary::-webkit-details-marker { display: none; }
-
-.summary-icon {
-  width: 28px;
-  height: 28px;
-  border-radius: 6px;
-  background: linear-gradient(135deg, var(--navy-light), var(--navy));
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  margin-top: 1px;
-}
-.summary-icon svg {
-  width: 13px;
-  height: 13px;
-  stroke: var(--gold-light);
-  fill: none;
-  stroke-width: 2;
-  stroke-linecap: round;
-}
-
-.summary-body { flex: 1; }
-
-.summary-title-row {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.summary-title {
-  font-weight: 500;
-  font-size: 0.92rem;
-  color: var(--navy);
-  line-height: 1.3;
-}
-.summary-title a {
-  color: inherit;
-  text-decoration: none;
-  transition: color 0.2s;
-}
-.summary-title a:hover { color: var(--gold); }
-
-.summary-meta {
-  font-size: 0.78rem;
-  color: var(--muted);
-  margin-top: 0.2rem;
-  font-weight: 300;
-}
-
-.chevron {
-  width: 16px;
-  height: 16px;
-  stroke: var(--muted);
-  fill: none;
-  stroke-width: 2;
-  stroke-linecap: round;
-  flex-shrink: 0;
-  margin-top: 4px;
-  transition: transform 0.25s;
-}
-details[open] .chevron { transform: rotate(90deg); }
-
-.detail-body {
-  padding: 0.9rem 1.2rem 1.1rem 3.2rem;
-  border-top: 1px solid var(--cream-dark);
-}
-
-.detail-body p, .detail-body div {
-  font-size: 0.84rem;
-  color: #4a5568;
-  line-height: 1.7;
-  font-weight: 300;
-}
-
-.detail-body a {
-  color: var(--gold);
-  text-decoration: none;
-  word-break: break-all;
-  font-size: 0.8rem;
-}
-.detail-body a:hover { text-decoration: underline; }
-
-.memory-delete-btn {
-  flex-shrink: 0;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: 1.1rem;
-  line-height: 1;
-  color: var(--muted);
-  padding: 0.1rem 0.3rem;
-  border-radius: 4px;
-  opacity: 0;
-  transition: opacity 0.15s, color 0.15s;
-}
-.memory-card:hover .memory-delete-btn { opacity: 1; }
-.memory-delete-btn:hover { color: #c00; }
-
-.attachments {
-  margin-top: 0.7rem;
-  font-size: 0.78rem;
-  color: var(--muted);
-}
-.attachments a {
-  font-size: 0.78rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  margin-right: 0.5rem;
-  color: var(--gold);
-}
-
-/* Add memory form */
-.add-memory-form {
-  margin-top: 1rem;
-  animation: fadeUp 0.5s 0.24s ease both;
-}
-
-.add-memory-input-row {
-  display: flex;
-  gap: 0.6rem;
-  background: var(--card-bg);
-  border: 1px solid var(--cream-dark);
-  border-radius: 8px;
-  padding: 0.5rem 0.5rem 0.5rem 1rem;
-  transition: border-color 0.2s, box-shadow 0.2s;
-}
-.add-memory-input-row:focus-within {
-  border-color: rgba(201,168,76,0.5);
-  box-shadow: 0 0 0 3px rgba(201,168,76,0.08);
-}
-
-.add-memory-input {
-  flex: 1;
-  border: none;
-  outline: none;
-  background: transparent;
-  font-family: 'DM Sans', system-ui, sans-serif;
-  font-size: 0.88rem;
-  color: var(--text);
-  font-weight: 300;
-}
-.add-memory-input::placeholder { color: var(--muted); }
-.add-memory-input:disabled { color: var(--muted); }
-
-.add-memory-visibility {
-  border: none;
-  outline: none;
-  background: transparent;
-  font-family: 'DM Sans', system-ui, sans-serif;
-  font-size: 0.82rem;
-  color: var(--muted);
-  font-weight: 400;
-  cursor: pointer;
-  padding: 0 0.2rem;
-  flex-shrink: 0;
-}
-.add-memory-visibility:disabled { opacity: 0.5; cursor: not-allowed; }
-
-.btn-add {
-  background: var(--navy);
-  color: var(--gold-light);
-  border: none;
-  padding: 0.55rem 1.2rem;
-  border-radius: 5px;
-  font-family: 'DM Sans', system-ui, sans-serif;
-  font-size: 0.82rem;
-  font-weight: 500;
-  cursor: pointer;
-  letter-spacing: 0.03em;
-  transition: background 0.2s, opacity 0.2s;
-}
-.btn-add:hover { background: var(--navy-light); }
-.btn-add:disabled { opacity: 0.4; cursor: not-allowed; }
-
-.add-memory-error-box {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  background: #fff0f0;
-  border: 1px solid #fcc;
-  border-radius: 6px;
-  padding: 0.5rem 0.75rem;
-  margin: 0.5rem 0 0;
-}
-
-.add-memory-error {
-  color: #c00;
-  font-size: 0.9rem;
-  margin: 0;
-  flex: 1;
-}
-
-.add-memory-error-dismiss {
-  background: none;
-  border: none;
-  color: #c00;
-  font-size: 1.1rem;
-  cursor: pointer;
-  padding: 0;
-  line-height: 1;
-}
-
-/* Dashboard */
-.section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-.section-header h2 {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
-  font-size: 0.75rem;
-  font-weight: 400;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--muted);
-  margin: 0;
-}
-
-.page-list {
-  list-style: none;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-}
-
-.page-card {
-  background: var(--card-bg);
-  border: 1px solid var(--cream-dark);
-  border-radius: 8px;
-  padding: 0.9rem 1.2rem;
-  transition: box-shadow 0.25s, border-color 0.25s, transform 0.2s;
-}
-.page-card:hover {
-  box-shadow: 0 4px 24px rgba(15,30,53,0.1);
-  border-color: rgba(201,168,76,0.3);
-  transform: translateY(-1px);
-}
-.page-card a {
-  text-decoration: none;
-  color: var(--navy);
-  font-weight: 500;
-  font-size: 0.92rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-.page-card a:hover { color: var(--gold); }
-
-.page-desc {
-  margin: 0.25rem 0 0;
-  color: var(--muted);
-  font-size: 0.82rem;
-  font-weight: 300;
-}
-
-.page-meta-tz {
-  margin: 0.25rem 0 0;
-  color: var(--muted);
-  font-size: 0.78rem;
-  font-weight: 300;
-}
-
-/* Landing / sign-in */
-.landing,
-.sign-in {
-  max-width: 480px;
-  margin: 4rem auto;
-  text-align: center;
-  padding: 0 1rem;
-}
-
-.landing h1 {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
-  font-size: 2rem;
-  font-weight: 600;
-  color: var(--navy);
-  margin-bottom: 0.5rem;
-}
-
-.landing p {
-  color: var(--muted);
-  margin-bottom: 2rem;
-}
-
-/* Forms */
-.create-page-form {
-  margin: 1rem 0;
-  padding: 1.2rem;
-  background: var(--card-bg);
-  border: 1px solid var(--cream-dark);
-  border-radius: 8px;
-}
-
-.form-field {
-  margin-bottom: 0.75rem;
-}
-
-.form-field label {
-  display: block;
-  font-size: 0.78rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--muted);
-  margin-bottom: 0.35rem;
-}
-
-.form-input {
-  width: 100%;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--cream-dark);
-  border-radius: 6px;
-  font-size: 0.88rem;
-  font-family: 'DM Sans', system-ui, sans-serif;
-  font-weight: 300;
-  background: var(--cream);
-  color: var(--text);
-  box-sizing: border-box;
-  transition: border-color 0.2s;
-}
-.form-input:focus {
-  outline: none;
-  border-color: rgba(201,168,76,0.5);
-  box-shadow: 0 0 0 3px rgba(201,168,76,0.08);
-}
-.form-input:disabled {
-  background: var(--cream-dark);
-  color: var(--muted);
-}
-
-.visibility-toggle {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.form-hint {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  margin-top: 0.2rem;
-}
-
-.upcoming-list {
-  margin-top: 0.75rem;
-}
-
-.upcoming-list-heading {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  margin: 0 0 0.35rem;
-}
-
-.upcoming-row {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--border);
-  text-decoration: none;
-  color: var(--text);
-  font-size: 0.85rem;
-}
-
-.upcoming-row:last-child {
-  border-bottom: none;
-}
-
-.upcoming-row:hover {
-  background: var(--surface-raised);
-}
-
-.upcoming-date {
-  min-width: 10rem;
-}
-
-.upcoming-location {
-  color: var(--text-muted);
-  font-size: 0.8rem;
-  flex: 1;
-  min-width: 0;
-}
 
-.upcoming-location-clickable {
-  cursor: pointer;
-  border-radius: var(--radius);
-  padding: 0.1rem 0.3rem;
-}
-
-.upcoming-location-clickable:hover {
-  background: var(--surface-raised);
-}
-
-.upcoming-location-input {
-  flex: 1;
-  min-width: 0;
-  padding: 0.15rem 0.35rem;
-  font-size: 0.82rem;
-}
-
-.rotation-row {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  margin-bottom: 0.35rem;
-}
-
-.rotation-row .form-input {
-  flex: 1;
-}
-
-.rotation-index {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  min-width: 1.2rem;
-}
-
-.form-error {
-  color: #c00;
-  font-size: 0.85rem;
-  margin: 0 0 0.75rem;
-}
-
-.form-actions {
-  display: flex;
-  gap: 0.5rem;
-}
-
-/* Page settings */
-.page-settings .page-header h1 {
-  border-bottom: none;
-  padding-bottom: 0;
-}
-
-.settings-page-title {
-  font-size: 0.9rem;
-  font-weight: normal;
-  color: var(--muted);
-}
-
-.settings-section {
-  margin-top: 1.5rem;
-}
-
-.settings-hint {
-  color: var(--muted);
-  font-size: 0.85rem;
-  margin: 0 0 0.75rem;
-}
-
-.settings-row {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.settings-row .form-input {
-  flex: 1;
-}
-
-.settings-ok {
-  color: #2e7d32;
-  font-size: 0.9rem;
-  margin: 0.5rem 0 0;
-}
-
-/* ============================================================
-   Phase 4 — Workspace, Series, Occurrence styles
-   Mobile-first: base is mobile, media queries add desktop
-   ============================================================ */
-
-/* Badges — v2 types */
-.badge {
-  display: inline-block;
-  padding: 0.15rem 0.5rem;
-  border-radius: 20px;
-  font-size: 0.72rem;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  margin-left: 0.5rem;
-  vertical-align: middle;
-}
-
-.badge-meeting    { background: rgba(15,30,53,0.1);  color: var(--navy); }
-.badge-reminder   { background: rgba(201,168,76,0.15); color: #7a5c00; }
-.badge-study      { background: rgba(46,125,50,0.12); color: #2e7d32; }
-.badge-personal   { background: rgba(201,168,76,0.15); color: #7a5c00; }
-.badge-public     { background: rgba(15,30,53,0.1);  color: var(--navy); }
-
-.badge-status-scheduled  { background: rgba(21,101,192,0.12); color: #1565c0; }
-.badge-status-confirmed  { background: rgba(46,125,50,0.12);  color: #2e7d32; }
-.badge-status-completed  { background: rgba(100,100,100,0.1); color: #555; }
-.badge-status-skipped    { background: rgba(230,81,0,0.12);   color: #e65100; }
-.badge-status-cancelled  { background: rgba(183,28,28,0.12);  color: #b71c1c; }
-.badge-status-active     { background: rgba(46,125,50,0.12);  color: #2e7d32; }
-
-.badge-ci-present { background: rgba(46,125,50,0.12);  color: #2e7d32; }
-.badge-ci-absent  { background: rgba(183,28,28,0.12);  color: #b71c1c; }
-.badge-ci-late    { background: rgba(230,81,0,0.12);   color: #e65100; }
-
-/* Workspace card extension */
-.workspace-card a {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-/* Workspace / Series view layout */
-.workspace-view {
-  position: relative;
-  z-index: 1;
-}
-
-.page-header {
-  padding: 1.5rem 1.25rem 1rem;
-  border-bottom: 1px solid var(--cream-dark);
-  margin-bottom: 0;
-}
-
-.page-header-top {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.75rem;
-}
-
-.back-link {
-  font-size: 0.82rem;
-  color: var(--muted);
-  text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.2rem;
-  transition: color 0.2s;
-}
-.back-link:hover { color: var(--gold); }
-
-.header-actions {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.page-title {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
-  font-size: 1.35rem;
-  font-weight: 600;
-  color: var(--navy);
-  line-height: 1.25;
-  margin: 0 0 0.25rem;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.3rem;
-}
-
-.series-meta {
-  font-size: 0.84rem;
-  color: var(--muted);
-  margin: 0.15rem 0;
-  font-weight: 300;
-}
-
-.series-meta-link { margin-top: 0.35rem; }
-
-.muted-link {
-  color: var(--muted);
-  text-decoration: none;
-  font-size: 0.82rem;
-}
-.muted-link:hover { color: var(--gold); text-decoration: underline; }
-
-.series-description {
-  margin-top: 0.4rem;
-  font-size: 0.88rem;
-  color: #4a5568;
-  font-weight: 300;
-  line-height: 1.5;
-}
-
-.series-location-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.6rem;
-}
-
-/* Chips */
-.location-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  background: var(--cream-dark);
-  border: 1px solid var(--border);
-  border-radius: 20px;
-  padding: 0.2rem 0.65rem;
-  font-size: 0.78rem;
-  color: var(--navy);
-  font-weight: 400;
-}
-
-.link-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  background: rgba(15,30,53,0.06);
-  border: 1px solid rgba(15,30,53,0.15);
-  border-radius: 20px;
-  padding: 0.2rem 0.65rem;
-  font-size: 0.78rem;
-  color: var(--navy);
-  text-decoration: none;
-  font-weight: 500;
-  transition: background 0.2s, color 0.2s;
-}
-.link-chip:hover {
-  background: var(--navy);
-  color: var(--gold-light);
-}
-
-/* Section */
-.section {
-  padding: 1.1rem 1.25rem;
-  border-bottom: 1px solid var(--cream-dark);
-}
-.section:last-child { border-bottom: none; }
-
-/* Series list */
-.series-list {
-  list-style: none;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  margin-top: 0.5rem;
-}
-
-.series-card {
-  background: var(--card-bg);
-  border: 1px solid var(--cream-dark);
-  border-radius: 10px;
-  padding: 1rem 1.15rem;
-  transition: box-shadow 0.2s, border-color 0.2s, transform 0.15s;
-}
-.series-card:hover {
-  box-shadow: 0 4px 20px rgba(15,30,53,0.08);
-  border-color: rgba(201,168,76,0.3);
-  transform: translateY(-1px);
-}
-
-.series-card-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0.3rem;
-  flex-wrap: wrap;
-  gap: 0.3rem;
-}
-
-.series-card-title {
-  font-weight: 600;
-  font-size: 0.95rem;
-  color: var(--navy);
-  text-decoration: none;
-  transition: color 0.2s;
-}
-.series-card-title:hover { color: var(--gold); }
-
-.series-card-schedule {
-  font-size: 0.82rem;
-  color: var(--muted);
-  margin: 0;
-  font-weight: 300;
-}
-
-.series-card-desc {
-  font-size: 0.82rem;
-  color: #4a5568;
-  margin: 0.25rem 0 0;
-  font-weight: 300;
-}
-
-.series-card-location {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-top: 0.5rem;
-}
-
-.series-card-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-top: 0.7rem;
-}
-
-/* Occurrence list */
-.occurrence-list {
-  list-style: none;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-}
-
-.occurrence-list-past {
-  opacity: 0.7;
-}
-
-.occurrence-card {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  background: var(--card-bg);
-  border: 1px solid var(--cream-dark);
-  border-radius: 8px;
-  padding: 0.7rem 1rem;
-  transition: box-shadow 0.2s, border-color 0.2s;
-}
-.occurrence-card:hover {
-  box-shadow: 0 2px 12px rgba(15,30,53,0.07);
-  border-color: rgba(201,168,76,0.25);
-}
-
-.occurrence-card-date {
-  font-size: 0.88rem;
-  font-weight: 500;
-  color: var(--navy);
-  text-decoration: none;
-  flex: 1;
-  min-width: 160px;
-}
-.occurrence-card-date:hover { color: var(--gold); }
-
-.occurrence-override-label {
-  font-size: 0.8rem;
-  font-style: italic;
-  color: var(--muted);
-}
-
-.occurrence-location {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-  width: 100%;
-  margin-top: 0.25rem;
-}
-
-/* Status row */
-.status-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-top: 0.25rem;
-}
-
-/* Location detail */
-.location-detail {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-  margin-top: 0.25rem;
-}
+.btn-secondary:hover:not(:disabled) { background: rgba(63,81,181,0.06); }
 
-.location-detail-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.88rem;
-  color: var(--text);
-}
-
-.location-label {
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--muted);
-  min-width: 64px;
-}
-
-.join-link {
-  color: var(--navy);
-  font-weight: 600;
-  text-decoration: none;
-  font-size: 0.92rem;
-  border-bottom: 2px solid var(--gold);
-  padding-bottom: 1px;
-  transition: color 0.2s, border-color 0.2s;
-}
-.join-link:hover { color: var(--gold); }
-
-.occurrence-notes {
-  font-size: 0.88rem;
-  color: #4a5568;
-  line-height: 1.6;
-  white-space: pre-wrap;
-  margin: 0.25rem 0 0;
-}
-
-/* Edit scope note */
-.edit-scope-note {
-  font-size: 0.75rem;
-  color: var(--muted);
-  font-style: italic;
-}
-
-/* Textarea */
-.form-textarea {
-  resize: vertical;
-  min-height: 80px;
-  font-family: 'DM Sans', system-ui, sans-serif;
-  line-height: 1.5;
-}
-
-/* Check-in list */
-.checkin-list {
-  list-style: none;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  margin-top: 0.25rem;
-}
-
-.checkin-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.84rem;
-  padding: 0.45rem 0.75rem;
-  background: var(--cream);
-  border-radius: 6px;
-  flex-wrap: wrap;
-}
-
-.checkin-uid {
-  font-family: monospace;
-  font-size: 0.78rem;
-  color: var(--muted);
-}
-
-.checkin-time {
-  color: var(--muted);
-  font-size: 0.78rem;
-}
-
-.checkin-note {
-  font-size: 0.82rem;
-  color: #4a5568;
-  font-style: italic;
-}
-
-/* Form helpers */
-.form-row {
-  display: flex;
-  gap: 0.75rem;
-}
-
-.form-field-half {
-  flex: 1;
-  min-width: 0;
-}
-
-/* Day-of-week toggle */
-.days-toggle {
-  display: flex;
-  gap: 0.35rem;
-  flex-wrap: wrap;
-}
-
-.btn-day {
-  min-width: 44px;
-  padding: 0.3rem 0.4rem;
-  text-align: center;
-}
-
-/* Placeholder helpers */
-.placeholder {
-  color: var(--muted);
-  font-size: 0.88rem;
-  font-weight: 300;
-  margin: 0.5rem 0;
-}
-
-.placeholder-sm {
-  color: var(--muted);
-  font-size: 0.82rem;
-  font-weight: 300;
-  margin: 0.25rem 0 0;
-}
+.btn-sm { padding: 4px 12px; font-size: 0.8rem; }
+.btn-xs { padding: 2px 8px; font-size: 0.75rem; }
 
 .btn-link {
   background: none;
   border: none;
-  color: var(--gold);
+  color: var(--primary);
   cursor: pointer;
-  font-size: 0.88rem;
+  font-size: inherit;
   padding: 0;
   text-decoration: underline;
 }
 
-/* ============================================================
-   Participant-facing summary page
-   Standalone — no AppShell, minimal chrome
-   ============================================================ */
+.btn-link:hover { color: var(--primary-dark); }
 
-.summary-page {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  background: var(--cream);
-  padding-bottom: 3rem;
-}
-
-.summary-cancelled-banner {
-  background: rgba(183,28,28,0.08);
-  border-bottom: 1px solid rgba(183,28,28,0.2);
-  color: #b71c1c;
-  text-align: center;
-  padding: 0.75rem 1rem;
-  font-size: 0.9rem;
-  font-weight: 500;
-}
-
-.summary-hero {
-  padding: 2.5rem 1.5rem 1.5rem;
-  border-bottom: 1px solid var(--cream-dark);
-  text-align: center;
-}
-
-.summary-title {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
-  font-size: 1.8rem;
-  font-weight: 700;
-  color: var(--navy);
-  margin: 0 0 0.5rem;
-  line-height: 1.2;
-}
-
-.summary-date {
-  font-size: 1.05rem;
-  color: var(--text);
-  margin: 0 0 0.25rem;
-  font-weight: 400;
-}
-
-.summary-duration {
-  font-size: 0.88rem;
-  color: var(--muted);
-  margin: 0;
-}
-
-.summary-series {
-  font-size: 0.82rem;
-  color: var(--muted);
-  margin-top: 0.5rem;
-  font-style: italic;
-}
-
-.summary-section {
-  padding: 1.25rem 1.5rem;
-  border-bottom: 1px solid var(--cream-dark);
-}
-
-.summary-section-title {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
-  font-size: 0.72rem;
-  font-weight: 400;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--muted);
-  margin: 0 0 0.75rem;
-}
-
-.summary-join-btn {
-  display: block;
-  background: var(--navy);
-  color: var(--gold-light);
-  border-radius: 8px;
-  padding: 0.9rem 1.5rem;
-  text-align: center;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1rem;
-  margin-bottom: 1rem;
-  transition: background 0.2s, opacity 0.2s;
-}
-.summary-join-btn:hover { background: var(--navy-light); opacity: 0.95; }
-
-.summary-location {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.92rem;
-  color: var(--text);
-}
-.summary-location svg { flex-shrink: 0; color: var(--muted); }
-
-.summary-notes {
-  font-size: 0.9rem;
-  color: #4a5568;
-  line-height: 1.6;
-  white-space: pre-wrap;
-  margin: 0;
-}
-
-.summary-share {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.summary-footer {
-  margin-top: auto;
-  padding: 1.5rem;
-  text-align: center;
+.btn-day {
+  min-width: 40px;
+  padding: 4px 6px;
   font-size: 0.75rem;
-  color: var(--muted);
-  letter-spacing: 0.04em;
+  border-radius: var(--radius-xs);
 }
 
-/* ============================================================
-   Responsive — desktop enhancements
-   ============================================================ */
+/* Main content */
+.main-content {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 12px 12px 24px;
+}
 
 @media (min-width: 640px) {
-  .navbar { padding: 0 2rem; }
-  .page-header {
-    padding: 2rem 2rem 1.25rem;
-  }
-  .section {
-    padding: 1.25rem 2rem;
-  }
-  .page-title { font-size: 1.6rem; }
-
-  .summary-hero { padding: 3.5rem 2rem 2rem; }
-  .summary-section { padding: 1.5rem 2rem; }
-  .summary-title { font-size: 2.2rem; }
-  .summary-join-btn { display: inline-block; padding: 1rem 2.5rem; }
+  .main-content { padding: 16px 16px 32px; }
+  .navbar { padding: 0 16px; }
+  .navbar-email { max-width: 200px; }
 }
 
-/* ============================================================
-   Phase 4 - Workspace, Series, Occurrence styles
-   Mobile-first: base is mobile, media queries add desktop
-   ============================================================ */
-
-/* Badges - v2 types */
-.badge {
-  display: inline-block;
-  padding: 0.15rem 0.5rem;
-  border-radius: 20px;
-  font-size: 0.72rem;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  margin-left: 0.5rem;
-  vertical-align: middle;
+/* Loading & Error */
+.loading {
+  color: var(--on-surface-variant);
+  font-style: italic;
+  padding: 24px 12px;
+  text-align: center;
+  font-size: 0.875rem;
 }
 
-.badge-meeting    { background: rgba(15,30,53,0.1);  color: var(--navy); }
-.badge-reminder   { background: rgba(201,168,76,0.15); color: #7a5c00; }
-.badge-study      { background: rgba(46,125,50,0.12); color: #2e7d32; }
-
-.badge-status-scheduled  { background: rgba(21,101,192,0.12); color: #1565c0; }
-.badge-status-confirmed  { background: rgba(46,125,50,0.12);  color: #2e7d32; }
-.badge-status-completed  { background: rgba(100,100,100,0.1); color: #555; }
-.badge-status-skipped    { background: rgba(230,81,0,0.12);   color: #e65100; }
-.badge-status-cancelled  { background: rgba(183,28,28,0.12);  color: #b71c1c; }
-.badge-status-active     { background: rgba(46,125,50,0.12);  color: #2e7d32; }
-
-.badge-ci-present { background: rgba(46,125,50,0.12);  color: #2e7d32; }
-.badge-ci-absent  { background: rgba(183,28,28,0.12);  color: #b71c1c; }
-.badge-ci-late    { background: rgba(230,81,0,0.12);   color: #e65100; }
-
-/* Workspace card extension */
-.workspace-card a {
+.loading-screen {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  flex-wrap: wrap;
+  justify-content: center;
+  min-height: 60vh;
+  color: var(--on-surface-variant);
+  font-size: 0.875rem;
 }
 
-/* Workspace / Series view layout */
-.workspace-view {
-  position: relative;
-  z-index: 1;
+.error-container {
+  padding: 24px 12px;
+  text-align: center;
 }
 
+.error-container .error {
+  color: var(--error);
+  margin-bottom: 12px;
+  font-size: 0.875rem;
+}
+
+.error-container a,
+.error-container button {
+  color: var(--primary);
+  font-size: 0.875rem;
+}
+
+.error-container button {
+  background: none;
+  border: 1px solid var(--outline-variant);
+  padding: 6px 16px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+/* Page Header */
 .page-header {
-  padding: 1.5rem 1.25rem 1rem;
-  border-bottom: 1px solid var(--cream-dark);
-  margin-bottom: 0;
+  padding: 8px 0 12px;
 }
 
 .page-header-top {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 4px;
 }
 
 .back-link {
-  font-size: 0.82rem;
-  color: var(--muted);
+  color: var(--primary);
   text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.2rem;
-  transition: color 0.2s;
+  font-size: 0.8rem;
+  font-weight: 500;
 }
-.back-link:hover { color: var(--gold); }
 
-.header-actions { display: flex; gap: 0.5rem; }
+.back-link:hover { text-decoration: underline; }
 
 .page-title {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
-  font-size: 1.35rem;
+  font-size: 1.25rem;
   font-weight: 600;
-  color: var(--navy);
-  line-height: 1.25;
-  margin: 0 0 0.25rem;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.3rem;
+  line-height: 1.3;
+  color: var(--on-surface);
 }
 
 .page-title-editable {
   cursor: pointer;
-  border-radius: var(--radius);
-  padding: 0.1rem 0.3rem;
-  margin-left: -0.3rem;
+  border-radius: var(--radius-xs);
+  padding: 2px 4px;
+  margin: -2px -4px;
 }
 
 .page-title-editable:hover {
-  background: var(--surface-raised);
+  background: rgba(0,0,0,0.04);
+}
+
+.page-meta-tz {
+  color: var(--on-surface-variant);
+  font-size: 0.8rem;
+  margin-top: 2px;
 }
 
 .inline-edit-title {
   display: flex;
+  gap: 6px;
   align-items: center;
-  gap: 0.4rem;
-  margin-bottom: 0.25rem;
+  margin-bottom: 4px;
 }
 
 .page-title-input {
-  font-size: 1.3rem;
+  flex: 1;
+  font-size: 1.1rem;
   font-weight: 600;
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
-  padding: 0.15rem 0.4rem;
 }
 
-.series-meta {
-  font-size: 0.84rem;
-  color: var(--muted);
-  margin: 0.15rem 0;
-  font-weight: 300;
-}
-
-.muted-link { color: var(--muted); text-decoration: none; font-size: 0.82rem; }
-.muted-link:hover { color: var(--gold); text-decoration: underline; }
-
-.series-description {
-  margin-top: 0.4rem;
-  font-size: 0.88rem;
-  color: #4a5568;
-  font-weight: 300;
-  line-height: 1.5;
-}
-
-.series-location-row {
+.header-actions {
   display: flex;
+  gap: 6px;
+}
+
+/* Sections */
+.section {
+  padding: 12px 0;
+  border-top: 1px solid var(--outline-variant);
+}
+
+.section:first-of-type {
+  border-top: none;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.section-header h2 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--on-surface-variant);
+}
+
+/* Forms */
+.form-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  font-family: inherit;
+  background: var(--surface);
+  color: var(--on-surface);
+  transition: border-color 0.15s;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 1px var(--primary);
+}
+
+.form-input-sm { padding: 4px 8px; font-size: 0.8rem; }
+.form-input-inline { width: auto; }
+
+.form-textarea { resize: vertical; min-height: 60px; }
+
+.form-field {
+  margin-bottom: 10px;
+}
+
+.form-field label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--on-surface-variant);
+  margin-bottom: 4px;
+}
+
+.form-field-half { flex: 1; min-width: 0; }
+
+.form-row {
+  display: flex;
+  gap: 8px;
+}
+
+.form-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.form-error {
+  color: var(--error);
+  font-size: 0.8rem;
+  margin-top: 4px;
+}
+
+.form-hint {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--on-surface-variant);
+  margin-top: 3px;
+}
+
+.create-page-form {
+  background: var(--surface);
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--radius);
+  padding: 12px;
+  margin-bottom: 12px;
+}
+
+/* Toggle groups */
+.visibility-toggle {
+  display: flex;
+  gap: 4px;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.6rem;
 }
 
-/* Chips */
-.location-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  background: var(--cream-dark);
-  border: 1px solid var(--border);
-  border-radius: 20px;
-  padding: 0.2rem 0.65rem;
-  font-size: 0.78rem;
-  color: var(--navy);
-  font-weight: 400;
+.days-toggle {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
 }
 
-.link-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  background: rgba(15,30,53,0.06);
-  border: 1px solid rgba(15,30,53,0.15);
-  border-radius: 20px;
-  padding: 0.2rem 0.65rem;
-  font-size: 0.78rem;
-  color: var(--navy);
+/* Dashboard */
+.dashboard {
+  padding: 4px 0;
+}
+
+.page-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.page-card {
+  background: var(--surface);
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  transition: background 0.15s;
+}
+
+.page-card:hover { background: var(--surface-container); }
+
+.page-card a {
+  color: var(--on-surface);
   text-decoration: none;
   font-weight: 500;
-  transition: background 0.2s, color 0.2s;
+  font-size: 0.9rem;
 }
-.link-chip:hover { background: var(--navy); color: var(--gold-light); }
 
-/* Section */
-.section {
-  padding: 1.1rem 1.25rem;
-  border-bottom: 1px solid var(--cream-dark);
-}
-.section:last-child { border-bottom: none; }
+.page-card a:hover { color: var(--primary); }
+
+.workspace-card { }
 
 /* Series list */
 .series-list {
   list-style: none;
-  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  margin-top: 0.5rem;
+  gap: 8px;
 }
 
 .series-card {
-  background: var(--card-bg);
-  border: 1px solid var(--cream-dark);
-  border-radius: 10px;
-  padding: 1rem 1.15rem;
-  transition: box-shadow 0.2s, border-color 0.2s, transform 0.15s;
-}
-.series-card:hover {
-  box-shadow: 0 4px 20px rgba(15,30,53,0.08);
-  border-color: rgba(201,168,76,0.3);
-  transform: translateY(-1px);
+  background: var(--surface);
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--radius);
+  padding: 10px 12px;
 }
 
 .series-card-top {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 0.3rem;
-  flex-wrap: wrap;
-  gap: 0.3rem;
+  gap: 8px;
+  margin-bottom: 2px;
 }
 
 .series-card-title {
-  font-weight: 600;
-  font-size: 0.95rem;
-  color: var(--navy);
+  font-weight: 500;
+  color: var(--on-surface);
   text-decoration: none;
-  transition: color 0.2s;
+  font-size: 0.9rem;
 }
-.series-card-title:hover { color: var(--gold); }
+
+.series-card-title:hover { color: var(--primary); }
 
 .series-card-schedule {
-  font-size: 0.82rem;
-  color: var(--muted);
-  margin: 0;
-  font-weight: 300;
+  font-size: 0.8rem;
+  color: var(--on-surface-variant);
+  margin-bottom: 4px;
 }
 
 .series-card-desc {
-  font-size: 0.82rem;
-  color: #4a5568;
-  margin: 0.25rem 0 0;
-  font-weight: 300;
+  font-size: 0.8rem;
+  color: var(--on-surface-variant);
+  margin-bottom: 4px;
 }
 
 .series-card-location {
   display: flex;
+  gap: 6px;
+  align-items: center;
   flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-top: 0.5rem;
+  margin-bottom: 4px;
 }
 
 .series-card-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-top: 0.7rem;
+  margin-top: 6px;
 }
 
-/* Occurrence list */
-.occurrence-list {
-  list-style: none;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-}
-.occurrence-list-past { opacity: 0.7; }
-
-.occurrence-card {
-  display: flex;
+/* Badges */
+.badge {
+  display: inline-flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  background: var(--card-bg);
-  border: 1px solid var(--cream-dark);
-  border-radius: 8px;
-  padding: 0.7rem 1rem;
-  transition: box-shadow 0.2s, border-color 0.2s;
-}
-.occurrence-card:hover {
-  box-shadow: 0 2px 12px rgba(15,30,53,0.07);
-  border-color: rgba(201,168,76,0.25);
-}
-
-.occurrence-card-date {
-  font-size: 0.88rem;
+  padding: 1px 8px;
+  border-radius: 100px;
+  font-size: 0.7rem;
   font-weight: 500;
-  color: var(--navy);
-  text-decoration: none;
-  flex: 1;
-  min-width: 160px;
+  text-transform: capitalize;
+  white-space: nowrap;
 }
-.occurrence-card-date:hover { color: var(--gold); }
 
-.occurrence-override-label {
+.badge-status-scheduled { background: rgba(63,81,181,0.1); color: var(--primary); }
+.badge-status-confirmed { background: rgba(46,125,50,0.1); color: var(--success); }
+.badge-status-completed { background: rgba(0,0,0,0.06); color: var(--on-surface-variant); }
+.badge-status-cancelled { background: rgba(0,0,0,0.06); color: var(--on-surface-variant); }
+.badge-status-rescheduled { background: rgba(230,81,0,0.1); color: var(--warning); }
+
+.badge-role-organizer { background: rgba(63,81,181,0.1); color: var(--primary); }
+.badge-role-participant { background: rgba(0,0,0,0.06); color: var(--on-surface-variant); }
+.badge-role-teacher { background: rgba(46,125,50,0.1); color: var(--success); }
+
+.badge-ci-ontime { background: rgba(46,125,50,0.1); color: var(--success); }
+.badge-ci-late { background: rgba(230,81,0,0.1); color: var(--warning); }
+
+/* Location / Link chips */
+.location-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  background: var(--surface-container);
+  border-radius: 100px;
+  font-size: 0.78rem;
+  color: var(--on-surface-variant);
+}
+
+.link-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  background: rgba(63,81,181,0.08);
+  border-radius: 100px;
+  font-size: 0.78rem;
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.link-chip:hover { background: rgba(63,81,181,0.14); }
+
+/* Series meta */
+.series-meta {
   font-size: 0.8rem;
-  font-style: italic;
-  color: var(--muted);
+  color: var(--on-surface-variant);
+  margin-top: 2px;
 }
 
-.occurrence-location {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-  width: 100%;
-  margin-top: 0.25rem;
-}
+.series-meta-link { margin-top: 4px; }
 
-/* Status row */
-.status-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-top: 0.25rem;
-}
-
-/* Location detail */
-.location-detail {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-  margin-top: 0.25rem;
-}
-
-.location-detail-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.88rem;
-  color: var(--text);
-}
-
-.location-label {
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--muted);
-  min-width: 64px;
-}
-
-.join-link {
-  color: var(--navy);
-  font-weight: 600;
+.muted-link {
+  color: var(--on-surface-variant);
   text-decoration: none;
-  font-size: 0.92rem;
-  border-bottom: 2px solid var(--gold);
-  padding-bottom: 1px;
-  transition: color 0.2s;
-}
-.join-link:hover { color: var(--gold); }
-
-.occurrence-notes {
-  font-size: 0.88rem;
-  color: #4a5568;
-  line-height: 1.6;
-  white-space: pre-wrap;
-  margin: 0.25rem 0 0;
 }
 
-.edit-scope-note {
-  font-size: 0.75rem;
-  color: var(--muted);
-  font-style: italic;
+.muted-link:hover { color: var(--primary); text-decoration: underline; }
+
+.series-description {
+  font-size: 0.85rem;
+  color: var(--on-surface-variant);
+  margin-top: 6px;
 }
 
-/* Textarea */
-.form-textarea {
-  resize: vertical;
-  min-height: 80px;
-  font-family: 'DM Sans', system-ui, sans-serif;
-  line-height: 1.5;
-}
-
-/* Check-in list */
-.checkin-list {
-  list-style: none;
-  padding: 0;
+.series-location-row {
   display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  margin-top: 0.25rem;
-}
-
-.checkin-item {
-  display: flex;
+  gap: 6px;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.84rem;
-  padding: 0.45rem 0.75rem;
-  background: var(--cream);
-  border-radius: 6px;
   flex-wrap: wrap;
-}
-
-.checkin-name { font-weight: 500; }
-.checkin-uid { font-family: monospace; font-size: 0.78rem; color: var(--muted); }
-.checkin-time { color: var(--muted); font-size: 0.78rem; margin-left: auto; }
-.checkin-note { font-size: 0.82rem; color: #4a5568; font-style: italic; }
-
-.checkin-done {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  background: rgba(46,125,50,0.08);
-  border: 1px solid rgba(46,125,50,0.2);
-  border-radius: 8px;
-}
-
-.checkin-done-label {
-  font-size: 1rem;
-  font-weight: 600;
-  color: #2e7d32;
+  margin-top: 6px;
 }
 
 /* Members */
 .members-list {
   list-style: none;
-  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 4px;
 }
+
 .member-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.84rem;
-  padding: 0.45rem 0.75rem;
-  background: var(--cream);
-  border-radius: 6px;
-}
-.member-uid { font-weight: 500; min-width: 5rem; }
-.badge-role-organizer { background: var(--gold); color: var(--navy); }
-.badge-role-participant { background: var(--cream-dark); color: var(--text); }
-.invite-section { margin-top: 0.75rem; }
-.invite-controls { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
-.form-input-inline { width: auto; min-width: 8rem; }
-.invite-link-box {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  margin-top: 0.5rem;
-}
-.invite-link-box .form-input {
-  flex: 1;
-  font-size: 0.82rem;
-  font-family: monospace;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 0.85rem;
 }
 
-/* Form helpers */
-.form-row { display: flex; gap: 0.75rem; }
-.form-field-half { flex: 1; min-width: 0; }
-
-/* Day-of-week toggle */
-.days-toggle { display: flex; gap: 0.35rem; flex-wrap: wrap; }
-.btn-day { min-width: 44px; padding: 0.3rem 0.4rem; text-align: center; }
-
-/* Placeholder helpers */
-.placeholder-sm {
-  color: var(--muted);
-  font-size: 0.82rem;
-  font-weight: 300;
-  margin: 0.25rem 0 0;
-}
-
-.btn-link {
-  background: none;
-  border: none;
-  color: var(--gold);
-  cursor: pointer;
-  font-size: 0.88rem;
-  padding: 0;
-  text-decoration: underline;
-}
-
-/* ============================================================
-   Participant-facing summary page
-   Standalone - no AppShell, minimal chrome
-   ============================================================ */
-
-.summary-page {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  background: var(--cream);
-  padding-bottom: 3rem;
-}
-
-.summary-cancelled-banner {
-  background: rgba(183,28,28,0.08);
-  border-bottom: 1px solid rgba(183,28,28,0.2);
-  color: #b71c1c;
-  text-align: center;
-  padding: 0.75rem 1rem;
-  font-size: 0.9rem;
-  font-weight: 500;
-}
-
-.summary-hero {
-  padding: 2.5rem 1.5rem 1.5rem;
-  border-bottom: 1px solid var(--cream-dark);
-  text-align: center;
-}
-
-.summary-title {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
-  font-size: 1.8rem;
-  font-weight: 700;
-  color: var(--navy);
-  margin: 0 0 0.5rem;
-  line-height: 1.2;
-}
-
-.summary-date {
-  font-size: 1.05rem;
-  color: var(--text);
-  margin: 0 0 0.25rem;
-  font-weight: 400;
-}
-
-.summary-duration { font-size: 0.88rem; color: var(--muted); margin: 0; }
-.summary-series { font-size: 0.82rem; color: var(--muted); margin-top: 0.5rem; font-style: italic; }
-
-.summary-section {
-  padding: 1.25rem 1.5rem;
-  border-bottom: 1px solid var(--cream-dark);
-}
-
-.summary-section-title {
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
-  font-size: 0.72rem;
-  font-weight: 400;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--muted);
-  margin: 0 0 0.75rem;
-}
-
-.summary-join-btn {
-  display: block;
-  background: var(--navy);
-  color: var(--gold-light);
-  border-radius: 8px;
-  padding: 0.9rem 1.5rem;
-  text-align: center;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 1rem;
-  margin-bottom: 1rem;
-  transition: background 0.2s, opacity 0.2s;
-}
-.summary-join-btn:hover { background: var(--navy-light); }
-
-.summary-location {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.92rem;
-  color: var(--text);
-}
-
-.summary-notes {
-  font-size: 0.9rem;
-  color: #4a5568;
-  line-height: 1.6;
-  white-space: pre-wrap;
-  margin: 0;
-}
-
-.summary-share { display: flex; gap: 0.5rem; flex-wrap: wrap; }
-
-.summary-footer {
-  margin-top: auto;
-  padding: 1.5rem;
-  text-align: center;
-  font-size: 0.75rem;
-  color: var(--muted);
-  letter-spacing: 0.04em;
-}
-
-/* Responsive - desktop enhancements */
-@media (min-width: 640px) {
-  .page-header { padding: 2rem 2rem 1.25rem; }
-  .section { padding: 1.25rem 2rem; }
-  .page-title { font-size: 1.6rem; }
-  .summary-hero { padding: 3.5rem 2rem 2rem; }
-  .summary-section { padding: 1.5rem 2rem; }
-  .summary-title { font-size: 2.2rem; }
-  .summary-join-btn { display: inline-block; padding: 1rem 2.5rem; }
-}
-
-
-/* ============================================================
-   Compact Chat
-   ============================================================ */
-
-.chat {
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  overflow: hidden;
-  background: var(--surface);
-  font-size: 0.82rem;
-}
-
-.chat-messages {
-  overflow-y: auto;
-  padding: 0.5rem 0.6rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  max-height: 240px;
-  min-height: 48px;
-}
-
-.chat-empty {
-  color: var(--text-muted);
-  font-size: 0.78rem;
-  text-align: center;
-  margin: 0;
-  padding: 0.5rem 0;
-}
-
-.chat-msg {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.3rem;
-  align-items: baseline;
-  line-height: 1.4;
-}
-
-.chat-msg-user {
-  justify-content: flex-end;
-}
-
-.chat-msg-user .chat-msg-text {
-  background: #4a6fa5;
-  color: #fff;
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.6rem 0.6rem 0.15rem 0.6rem;
-  max-width: 85%;
-  white-space: pre-wrap;
-}
-
-.chat-msg-assistant .chat-msg-text {
-  background: var(--surface-raised);
-  border: 1px solid var(--border);
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.6rem 0.6rem 0.6rem 0.15rem;
-  max-width: 85%;
-  white-space: pre-wrap;
-}
-
-.chat-proposal {
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
-  flex-wrap: wrap;
-  background: #fff8e1;
-  border: 1px solid #f0c040;
-  border-radius: 0.4rem;
-  padding: 0.2rem 0.4rem;
-  font-size: 0.78rem;
-  width: 100%;
-}
-
-.chat-proposal-text {
+.member-uid {
   flex: 1;
   min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-/* Thinking dots */
-.chat-dots {
-  display: inline-flex;
+/* Invite */
+.invite-section { margin-top: 8px; }
+
+.invite-controls {
+  display: flex;
+  gap: 6px;
   align-items: center;
-  gap: 0.2rem;
-  padding: 0.25rem 0.5rem;
-  background: var(--surface-raised);
-  border: 1px solid var(--border);
-  border-radius: 0.6rem;
+  flex-wrap: wrap;
 }
 
-.chat-dots span {
-  width: 5px;
-  height: 5px;
-  background: var(--text-muted);
-  border-radius: 50%;
-  animation: chat-bounce 1.2s infinite;
-}
-
-.chat-dots span:nth-child(2) { animation-delay: 0.2s; }
-.chat-dots span:nth-child(3) { animation-delay: 0.4s; }
-
-@keyframes chat-bounce {
-  0%, 60%, 100% { transform: translateY(0); }
-  30% { transform: translateY(-3px); }
-}
-
-.chat-error {
-  padding: 0.2rem 0.6rem;
-  font-size: 0.75rem;
-  color: var(--error, #d32f2f);
-  background: #fff1f1;
-  margin: 0;
-}
-
-.chat-input-row {
+.invite-link-box {
   display: flex;
-  gap: 0.3rem;
-  padding: 0.35rem 0.5rem;
-  border-top: 1px solid var(--border);
-  background: var(--surface-raised);
+  gap: 6px;
+  margin-top: 6px;
 }
 
-.chat-input {
-  flex: 1;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0.3rem 0.5rem;
-  font-size: 0.82rem;
-  font-family: inherit;
-  background: var(--surface);
-  color: var(--text);
-}
+.invite-link-box .form-input { flex: 1; }
 
-.chat-input:focus {
-  outline: none;
-  border-color: var(--accent);
-}
-
-.chat-send {
-  align-self: center;
-}
-
-.btn-xs {
-  padding: 0.15rem 0.4rem;
-  font-size: 0.72rem;
-  border-radius: 0.3rem;
-}
-
-/* ============================================================
-   Inline Markdown
-   ============================================================ */
-
-.md-line { margin: 0.15rem 0; }
-.md-line:empty::before { content: "\00a0"; }
-.md-line a { color: #3182ce; text-decoration: underline; }
-.md-line a:hover { opacity: 0.8; }
-
-/* ============================================================
-   Meeting Cards (last/next on series page)
-   ============================================================ */
-
+/* Meeting cards */
 .meeting-card {
-  padding: 0.75rem;
-  border: 1px solid var(--border);
+  background: var(--surface);
+  border: 1px solid var(--outline-variant);
   border-radius: var(--radius);
-  margin-bottom: 0.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
+  padding: 10px 12px;
+  margin-bottom: 8px;
 }
 
 .meeting-card-past {
   opacity: 0.7;
 }
 
-.meeting-card-next {
-  border-color: var(--accent, #3182ce);
-  border-width: 2px;
+.meeting-card-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--on-surface-variant);
+  margin-bottom: 2px;
 }
 
 .meeting-card-header {
@@ -2101,91 +607,558 @@ details[open] .chevron { transform: rotate(90deg); }
   justify-content: space-between;
 }
 
-.meeting-card-label {
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-muted);
+.meeting-card-date {
+  color: var(--on-surface);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.9rem;
 }
 
-.meeting-card-date {
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: var(--text);
-  text-decoration: none;
+.meeting-card-date:hover { color: var(--primary); }
+
+.meeting-card-notes {
+  font-size: 0.8rem;
+  color: var(--on-surface-variant);
+  margin-top: 4px;
 }
-.meeting-card-date:hover { text-decoration: underline; }
 
 .meeting-card-location {
   font-size: 0.8rem;
-  color: var(--text-muted);
+  color: var(--on-surface-variant);
+  margin-top: 2px;
 }
 
-.meeting-card-notes {
-  font-size: 0.82rem;
-  color: #4a5568;
-  line-height: 1.4;
-  margin: 0;
-  white-space: pre-wrap;
+.next-meeting-edit { margin-top: 8px; }
+
+/* Upcoming list */
+.upcoming-list { margin-top: 8px; }
+
+.upcoming-list-heading {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--on-surface-variant);
+  margin-bottom: 6px;
 }
 
-/* Toggle row (checkbox + label) */
+.upcoming-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--surface-container);
+  font-size: 0.85rem;
+}
+
+.upcoming-date {
+  min-width: 0;
+  flex-shrink: 0;
+  color: var(--on-surface);
+  text-decoration: none;
+  font-size: 0.8rem;
+}
+
+.upcoming-date:hover { color: var(--primary); }
+
+.upcoming-location {
+  flex: 1;
+  color: var(--on-surface-variant);
+  font-size: 0.8rem;
+  text-align: right;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.upcoming-location-clickable {
+  cursor: pointer;
+  border-radius: var(--radius-xs);
+  padding: 2px 4px;
+}
+
+.upcoming-location-clickable:hover { background: rgba(0,0,0,0.04); }
+
+.upcoming-location-input { flex: 1; }
+
+/* Rotation */
+.rotation-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.rotation-index {
+  font-size: 0.8rem;
+  color: var(--on-surface-variant);
+  min-width: 18px;
+}
+
+.rotation-row .form-input { flex: 1; }
+
+/* Status row */
+.status-row {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+/* Toggle row */
 .toggle-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.75rem;
-  font-size: 0.9rem;
+  gap: 8px;
+  font-size: 0.85rem;
   cursor: pointer;
 }
 
-/* Check-in report table */
-.report-controls {
-  margin-bottom: 0.75rem;
+.toggle-row input[type="checkbox"] {
+  accent-color: var(--primary);
+  width: 16px;
+  height: 16px;
+}
+
+/* Location detail */
+.location-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.location-detail-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-size: 0.85rem;
 }
-.report-window-select {
-  display: inline-block;
-  width: auto;
-  padding: 0.15rem 0.4rem;
-  font-size: 0.85rem;
+
+.location-icon {
+  display: flex;
+  align-items: center;
+  color: var(--on-surface-variant);
 }
-.report-table-wrap {
-  overflow-x: auto;
-}
-.report-table {
-  border-collapse: collapse;
-  font-size: 0.82rem;
-  width: 100%;
-}
-.report-table th,
-.report-table td {
-  padding: 0.35rem 0.5rem;
-  border: 1px solid var(--border);
-  text-align: center;
-  white-space: nowrap;
-}
-.report-name-col {
-  text-align: left !important;
-  position: sticky;
-  left: 0;
-  background: white;
-  z-index: 1;
-  min-width: 7rem;
-}
-.report-date-col a {
-  color: inherit;
+
+.location-icon svg { width: 16px; height: 16px; }
+
+.join-link {
+  color: var(--primary);
   text-decoration: none;
+}
+
+.join-link:hover { text-decoration: underline; }
+
+/* Notes */
+.occurrence-notes {
+  font-size: 0.85rem;
+  color: var(--on-surface);
+  white-space: pre-wrap;
+}
+
+.edit-scope-note {
+  font-size: 0.7rem;
+  color: var(--on-surface-variant);
+  font-style: italic;
+}
+
+/* Check-in */
+.checkin-done {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.checkin-done-label {
+  font-weight: 500;
+  color: var(--success);
+  font-size: 0.9rem;
+}
+
+.checkin-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.checkin-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+}
+
+.checkin-name { font-weight: 500; }
+
+.checkin-time {
+  color: var(--on-surface-variant);
   font-size: 0.75rem;
 }
-.report-date-col a:hover {
+
+/* Placeholders */
+.placeholder {
+  color: var(--on-surface-variant);
+  font-size: 0.85rem;
+  padding: 4px 0;
+}
+
+.placeholder-sm {
+  color: var(--on-surface-variant);
+  font-size: 0.8rem;
+}
+
+/* Markdown */
+.md-line {
+  margin-bottom: 2px;
+  line-height: 1.5;
+}
+
+.md-line a {
+  color: var(--primary);
   text-decoration: underline;
 }
-.report-cell-done {
-  color: #38a169;
+
+.md-line a:hover { color: var(--primary-dark); }
+
+/* Landing & Sign-in */
+.landing,
+.sign-in {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
+  text-align: center;
+  padding: 24px 16px;
+}
+
+.landing h1,
+.sign-in h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+  color: var(--on-surface);
+}
+
+.landing p {
+  color: var(--on-surface-variant);
+  margin-bottom: 20px;
+  font-size: 0.9rem;
+}
+
+/* Summary page */
+.summary-page {
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 16px 12px;
+}
+
+.summary-cancelled-banner {
+  background: rgba(179,38,30,0.08);
+  color: var(--error);
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  text-align: center;
+  font-size: 0.85rem;
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+
+.summary-hero {
+  padding: 16px 0 12px;
+  text-align: center;
+}
+
+.summary-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.summary-date {
+  color: var(--on-surface-variant);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.summary-duration {
+  color: var(--on-surface-variant);
+  font-size: 0.85rem;
+}
+
+.summary-series {
+  color: var(--on-surface-variant);
+  font-size: 0.8rem;
+  margin-top: 4px;
+}
+
+.summary-section {
+  border-top: 1px solid var(--outline-variant);
+  padding: 12px 0;
+}
+
+.summary-section-title {
+  font-size: 0.8rem;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--on-surface-variant);
+  margin-bottom: 6px;
 }
-.report-cell-miss {
-  color: #a0aec0;
+
+.summary-join-btn {
+  display: block;
+  text-align: center;
+  padding: 10px 16px;
+  background: var(--primary);
+  color: var(--on-primary);
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.9rem;
+  margin-bottom: 8px;
 }
+
+.summary-join-btn:hover { background: var(--primary-dark); }
+
+.summary-location {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: var(--on-surface);
+}
+
+.summary-location svg { color: var(--on-surface-variant); flex-shrink: 0; }
+
+.summary-notes {
+  font-size: 0.85rem;
+  color: var(--on-surface);
+  white-space: pre-wrap;
+}
+
+.summary-share {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.summary-footer {
+  text-align: center;
+  padding: 16px 0;
+  font-size: 0.75rem;
+  color: var(--on-surface-variant);
+}
+
+/* Chat */
+.chat {
+  background: var(--surface);
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.chat-messages {
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.chat-empty {
+  color: var(--on-surface-variant);
+  font-size: 0.8rem;
+  text-align: center;
+  padding: 12px 0;
+}
+
+.chat-msg {
+  display: flex;
+}
+
+.chat-msg-user { justify-content: flex-end; }
+.chat-msg-assistant { justify-content: flex-start; }
+
+.chat-msg-text {
+  max-width: 85%;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.chat-msg-user .chat-msg-text {
+  background: var(--primary);
+  color: var(--on-primary);
+  border-bottom-right-radius: var(--radius-xs);
+}
+
+.chat-msg-assistant .chat-msg-text {
+  background: var(--surface-container);
+  color: var(--on-surface);
+  border-bottom-left-radius: var(--radius-xs);
+}
+
+.chat-proposal {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: rgba(63,81,181,0.06);
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--radius-sm);
+  padding: 8px;
+  max-width: 85%;
+  font-size: 0.8rem;
+}
+
+.chat-proposal-text { color: var(--on-surface); }
+
+.chat-error {
+  color: var(--error);
+  font-size: 0.78rem;
+  padding: 4px 8px;
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 6px;
+  padding: 6px 8px;
+  border-top: 1px solid var(--outline-variant);
+}
+
+.chat-input {
+  flex: 1;
+  padding: 6px 10px;
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  font-family: inherit;
+  background: var(--surface);
+  color: var(--on-surface);
+}
+
+.chat-input:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+.chat-send { flex-shrink: 0; }
+
+/* Chat dots animation */
+.chat-dots {
+  display: inline-flex;
+  gap: 3px;
+  padding: 8px 12px;
+}
+
+.chat-dots span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--on-surface-variant);
+  animation: chatDot 1.2s infinite ease-in-out;
+}
+
+.chat-dots span:nth-child(2) { animation-delay: 0.2s; }
+.chat-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes chatDot {
+  0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1); }
+}
+
+/* Report table */
+.report-controls {
+  margin-bottom: 8px;
+  font-size: 0.8rem;
+  color: var(--on-surface-variant);
+}
+
+.report-window-select {
+  width: auto;
+  display: inline;
+  padding: 2px 4px;
+  font-size: 0.8rem;
+}
+
+.report-table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.report-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+
+.report-table th,
+.report-table td {
+  padding: 4px 6px;
+  text-align: center;
+  border-bottom: 1px solid var(--outline-variant);
+}
+
+.report-name-col {
+  text-align: left;
+  min-width: 80px;
+  position: sticky;
+  left: 0;
+  background: var(--surface);
+  z-index: 1;
+  font-weight: 500;
+}
+
+.report-date-col {
+  font-size: 0.7rem;
+  white-space: nowrap;
+}
+
+.report-date-col a {
+  color: var(--on-surface-variant);
+  text-decoration: none;
+}
+
+.report-date-col a:hover { color: var(--primary); }
+
+.report-cell { white-space: nowrap; }
+.report-cell-done { color: var(--success); font-weight: 500; }
+.report-cell-miss { color: var(--on-surface-variant); }
+
+/* Accept invite (used by AcceptInvite.tsx) */
+.invite-page {
+  text-align: center;
+  padding: 32px 16px;
+}
+
+.invite-page h2 {
+  font-size: 1.25rem;
+  margin-bottom: 8px;
+}
+
+.invite-page p {
+  color: var(--on-surface-variant);
+  margin: 8px 0 16px;
+  font-size: 0.9rem;
+}
+
+.invite-page .form-error {
+  margin-bottom: 12px;
+}
+
+.invite-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-thumb { background: var(--outline-variant); border-radius: 3px; }
+::-webkit-scrollbar-track { background: transparent; }


### PR DESCRIPTION
Rewrite web CSS to match Flutter's Material 3 indigo palette, adopt mobile-first spacing (8px scale), remove ~900 lines of duplicate CSS, and fix all undefined CSS variables. Enrich Flutter screens with cards, avatars, icons, date blocks, and section headers to fill blank space. Rename branding from "Meeting Assistant" to "Event Ledger" everywhere.