### PR TITLE
Give assistant query tools to look up occurrences on demand

### DIFF
--- a/src/assistant.py
+++ b/src/assistant.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "gemini-2.5-flash"
 _MAX_RETRIES = 2
+_MAX_TOOL_ROUNDS = 5
 
 # ---------------------------------------------------------------------------
 # Prompt
@@ -44,11 +45,10 @@ _MAX_RETRIES = 2
 _SYSTEM_PROMPT = """You are an AI assistant for a meeting organizer. Help organizers manage recurring
 meetings, schedules, and materials through natural conversation.
 
-You have access to the room's current data provided in the "Room context" section below.
-Use this data to answer questions about series, occurrences, schedules, hosts, and locations.
-When the user asks about meetings or series, always check the room context first — it contains
-the list of series, upcoming occurrences, and recent past occurrences (last 7 days) for this room.
-You can update agendas/notes for both upcoming AND recent past occurrences.
+The room's series are listed in the "Room context" section. To find specific occurrences,
+use the list_occurrences tool with a series_id and optional date range. Use get_occurrence
+to fetch full details of a specific occurrence. Always look up occurrence IDs via these tools
+before proposing update_occurrence or reschedule_occurrence actions.
 
 Available actions:
   create_series            — create a new recurring meeting series
@@ -62,10 +62,11 @@ Available actions:
   general_question         — answer without performing any state change
 
 For each message:
-  1. Determine the INTENT (one of the six above).
-  2. Write a short, friendly RESPONSE (1-3 sentences).
-  3. If the intent is state-changing, produce a structured ACTION PAYLOAD.
-  4. If no action is needed, set "action" to null.
+  1. If you need occurrence IDs, call list_occurrences (and optionally get_occurrence) first.
+  2. Determine the INTENT (one of the actions above).
+  3. Write a short, friendly RESPONSE (1-3 sentences).
+  4. If the intent is state-changing, produce a structured ACTION PAYLOAD.
+  5. If no action is needed, set "action" to null.
 
 IMPORTANT: When the intent is state-changing, your response_text should describe what
 you WILL do (e.g. "I'll update the agenda for..."), NOT what you HAVE done. The action
@@ -112,34 +113,87 @@ All items will be executed together when the user confirms.
 """
 
 
-def _build_prompt(
+def _build_contents(
     message: str,
     room_context: dict[str, Any] | None,
     history: list[dict[str, str]] | None = None,
-) -> str:
+) -> list:
+    from google.genai import types
     from datetime import datetime, timezone
+
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    ctx = f"\nToday's date: {today}\n"
+    ctx = f"Today's date: {today}\n"
     if room_context:
         ctx += "\nRoom context:\n" + json.dumps(room_context, indent=2, default=str) + "\n"
-    conv = ""
+
+    contents = []
     if history:
-        for turn in history:
-            role = turn.get("role", "user")
+        for i, turn in enumerate(history):
+            role = "model" if turn.get("role") == "assistant" else "user"
             text = turn.get("text", "")
-            if role == "user":
-                conv += f"\nUser: {text}"
-            else:
-                conv += f"\nAssistant: {text}"
-        conv += "\n"
-    return _SYSTEM_PROMPT + ctx + conv + f"\nUser: {message}"
+            if i == 0 and role == "user":
+                text = ctx + text
+            contents.append(types.Content(role=role, parts=[types.Part(text=text)]))
+        contents.append(types.Content(role="user", parts=[types.Part(text=message)]))
+    else:
+        contents.append(types.Content(role="user", parts=[types.Part(text=ctx + message)]))
+
+    return contents
 
 
 # ---------------------------------------------------------------------------
-# Gemini call (JSON mode)
+# Query tools
 # ---------------------------------------------------------------------------
 
-def _call_ai(prompt: str) -> dict:
+def _execute_query_tool(name: str, args: dict, room_id: str) -> dict:
+    """Execute a query tool call against series_storage and return a result dict."""
+    import series_storage as _ss
+    if name == "list_occurrences":
+        series_id = args.get("series_id", "")
+        occs = _ss.list_occurrences_for_series(series_id)
+        after = args.get("scheduled_after")
+        before = args.get("scheduled_before")
+        if after:
+            occs = [o for o in occs if o.scheduled_for >= after]
+        if before:
+            occs = [o for o in occs if o.scheduled_for < before]
+        limit = min(int(args.get("limit", 10)), 50)
+        return {
+            "occurrences": [
+                {
+                    "occurrence_id": o.occurrence_id,
+                    "series_id": o.series_id,
+                    "scheduled_for": o.scheduled_for,
+                    "status": o.status,
+                    "host": o.host,
+                    "location": o.location,
+                    "notes": o.overrides.notes if o.overrides else None,
+                }
+                for o in occs[:limit]
+            ]
+        }
+    if name == "get_occurrence":
+        occ = _ss.get_occurrence(args.get("occurrence_id", ""))
+        if occ is None:
+            return {"error": f"Occurrence not found: {args.get('occurrence_id')}"}
+        return {
+            "occurrence_id": occ.occurrence_id,
+            "series_id": occ.series_id,
+            "scheduled_for": occ.scheduled_for,
+            "status": occ.status,
+            "host": occ.host,
+            "location": occ.location,
+            "notes": occ.overrides.notes if occ.overrides else None,
+            "links": occ.links,
+        }
+    return {"error": f"Unknown tool: {name}"}
+
+
+# ---------------------------------------------------------------------------
+# Gemini call (function-calling loop + JSON final response)
+# ---------------------------------------------------------------------------
+
+def _call_ai(contents: list, room_id: str) -> dict:
     from google import genai
     from google.genai import types
 
@@ -152,31 +206,115 @@ def _call_ai(prompt: str) -> dict:
     model = os.environ.get("GEMINI_MODEL", _DEFAULT_MODEL)
     client = genai.Client(api_key=api_key)
 
+    query_tools = types.Tool(
+        function_declarations=[
+            types.FunctionDeclaration(
+                name="list_occurrences",
+                description="List occurrences for a series, filtered by optional date range.",
+                parameters=types.Schema(
+                    type=types.Type.OBJECT,
+                    properties={
+                        "series_id": types.Schema(
+                            type=types.Type.STRING,
+                            description="Series ID to query",
+                        ),
+                        "scheduled_after": types.Schema(
+                            type=types.Type.STRING,
+                            description="ISO 8601 UTC lower bound (inclusive)",
+                        ),
+                        "scheduled_before": types.Schema(
+                            type=types.Type.STRING,
+                            description="ISO 8601 UTC upper bound (exclusive)",
+                        ),
+                        "limit": types.Schema(
+                            type=types.Type.INTEGER,
+                            description="Max results to return (default 10, max 50)",
+                        ),
+                    },
+                    required=["series_id"],
+                ),
+            ),
+            types.FunctionDeclaration(
+                name="get_occurrence",
+                description="Get full details of a single occurrence by ID.",
+                parameters=types.Schema(
+                    type=types.Type.OBJECT,
+                    properties={
+                        "occurrence_id": types.Schema(
+                            type=types.Type.STRING,
+                            description="Occurrence ID",
+                        ),
+                    },
+                    required=["occurrence_id"],
+                ),
+            ),
+        ]
+    )
+
+    config = types.GenerateContentConfig(
+        system_instruction=_SYSTEM_PROMPT,
+        tools=[query_tools],
+    )
+
     last_exc: Exception | None = None
     for attempt in range(_MAX_RETRIES):
-        response = client.models.generate_content(
-            model=model,
-            contents=prompt,
-            config=types.GenerateContentConfig(
-                response_mime_type="application/json",
-            ),
-        )
-        text = response.text
-        if not text or not text.strip():
-            last_exc = ValueError("Gemini returned an empty response")
-            logger.warning("assistant AI attempt %d: empty response", attempt + 1)
-            continue
+        working_contents = list(contents)
+        response = None
         try:
+            for _ in range(_MAX_TOOL_ROUNDS):
+                response = client.models.generate_content(
+                    model=model,
+                    contents=working_contents,
+                    config=config,
+                )
+                working_contents.append(response.candidates[0].content)
+
+                fn_calls = [
+                    p for p in (response.candidates[0].content.parts or [])
+                    if p.function_call
+                ]
+                if not fn_calls:
+                    break
+
+                tool_parts = []
+                for part in fn_calls:
+                    result = _execute_query_tool(
+                        part.function_call.name,
+                        dict(part.function_call.args),
+                        room_id,
+                    )
+                    logger.info(
+                        "Tool %s args=%s → %d keys",
+                        part.function_call.name,
+                        dict(part.function_call.args),
+                        len(result),
+                    )
+                    tool_parts.append(
+                        types.Part(
+                            function_response=types.FunctionResponse(
+                                name=part.function_call.name,
+                                response=result,
+                            )
+                        )
+                    )
+                working_contents.append(types.Content(role="user", parts=tool_parts))
+
+            if response is None:
+                raise ValueError("No response from AI")
+
+            text = response.text
+            if not text or not text.strip():
+                raise ValueError("Gemini returned an empty response")
+
             result = json.loads(text)
-        except (json.JSONDecodeError, TypeError) as exc:
+            if not isinstance(result, dict) or "intent" not in result:
+                raise ValueError(f"Unexpected AI response shape: {result!r}")
+            return result
+
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
             last_exc = exc
-            logger.warning("assistant AI attempt %d: invalid JSON: %s", attempt + 1, exc)
+            logger.warning("assistant AI attempt %d failed: %s", attempt + 1, exc)
             continue
-        if not isinstance(result, dict) or "intent" not in result:
-            last_exc = ValueError(f"Unexpected AI response shape: {result!r}")
-            logger.warning("assistant AI attempt %d: bad shape", attempt + 1)
-            continue
-        return result
 
     raise last_exc or ValueError("AI call failed after retries")
 
@@ -240,9 +378,9 @@ def run_assistant_stream(
     """Stream assistant events for an organizer message."""
     yield {"type": "status", "message": "Thinking\u2026"}
 
-    prompt = _build_prompt(message, room_context, history)
+    contents = _build_contents(message, room_context, history)
     try:
-        ai_result = _call_ai(prompt)
+        ai_result = _call_ai(contents, room_id)
     except Exception as exc:
         logger.exception("AI call failed in assistant stream")
         yield {"type": "error", "message": str(exc)}

--- a/src/telegram_chat_handler.py
+++ b/src/telegram_chat_handler.py
@@ -64,23 +64,15 @@ async def _answer_callback_query(bot_token: str, callback_query_id: str) -> None
 
 
 def _build_room_context(room_id: str) -> dict | None:
-    """Build a room context dict for the assistant, matching the app's pattern."""
-    from datetime import timedelta
+    """Build a room context dict for the assistant (series metadata only).
 
+    Occurrences are not pre-fetched; the assistant queries them on demand
+    via the list_occurrences / get_occurrence tools.
+    """
     room = room_storage.get_room(room_id)
     if room is None:
         return None
     all_series = series_storage.list_series_for_room(room_id)
-
-    # Include both scheduled and recent past occurrences so the AI can
-    # update agendas for occurrences that just happened or are today.
-    all_occs = series_storage.list_occurrences_for_room(room_id)
-    cutoff = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
-    occs = [
-        o for o in all_occs
-        if o.status == "scheduled" or o.scheduled_for >= cutoff
-    ]
-
     return {
         "room_id": room.room_id,
         "title": room.title,
@@ -96,19 +88,6 @@ def _build_room_context(room_id: str) -> dict | None:
                 "status": s.status,
             }
             for s in all_series
-        ],
-        "upcoming_occurrences": [
-            {
-                "occurrence_id": o.occurrence_id,
-                "series_id": o.series_id,
-                "scheduled_for": o.scheduled_for,
-                "status": o.status,
-                "host": o.host,
-                "location": o.location,
-                "notes": o.overrides.notes if o.overrides else None,
-                "title_override": o.overrides.title if o.overrides else None,
-            }
-            for o in occs[:20]
         ],
     }
 

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from assistant import _execute_query_tool
 from assistant_actions import (
     ACTION_TTL_SECONDS,
     PendingAction,
@@ -502,3 +503,65 @@ class TestAssistantAPI:
         data = resp.json()
         assert data["status"] == "executed"
         assert data["result"]["material_kind"] == "notes"
+
+
+# ---------------------------------------------------------------------------
+# _execute_query_tool
+# ---------------------------------------------------------------------------
+
+class TestExecuteQueryTool:
+    def _make_occurrence(self, occ_id="occ-1", series_id="s-1", scheduled_for="2026-06-01T10:00:00+00:00"):
+        from models import Occurrence
+        return Occurrence(
+            occurrence_id=occ_id,
+            series_id=series_id,
+            room_id="rm-1",
+            scheduled_for=scheduled_for,
+            host="Alice",
+        )
+
+    def test_list_occurrences_returns_summaries(self):
+        occ = self._make_occurrence()
+        with patch("series_storage.list_occurrences_for_series", return_value=[occ]):
+            result = _execute_query_tool("list_occurrences", {"series_id": "s-1"}, "rm-1")
+        assert len(result["occurrences"]) == 1
+        assert result["occurrences"][0]["occurrence_id"] == "occ-1"
+        assert result["occurrences"][0]["host"] == "Alice"
+
+    def test_list_occurrences_date_filter(self):
+        occs = [
+            self._make_occurrence("occ-1", scheduled_for="2026-05-01T10:00:00+00:00"),
+            self._make_occurrence("occ-2", scheduled_for="2026-06-01T10:00:00+00:00"),
+            self._make_occurrence("occ-3", scheduled_for="2026-07-01T10:00:00+00:00"),
+        ]
+        with patch("series_storage.list_occurrences_for_series", return_value=occs):
+            result = _execute_query_tool(
+                "list_occurrences",
+                {"series_id": "s-1", "scheduled_after": "2026-05-15T00:00:00+00:00", "scheduled_before": "2026-06-15T00:00:00+00:00"},
+                "rm-1",
+            )
+        assert len(result["occurrences"]) == 1
+        assert result["occurrences"][0]["occurrence_id"] == "occ-2"
+
+    def test_list_occurrences_respects_limit(self):
+        occs = [self._make_occurrence(f"occ-{i}") for i in range(20)]
+        with patch("series_storage.list_occurrences_for_series", return_value=occs):
+            result = _execute_query_tool("list_occurrences", {"series_id": "s-1", "limit": 5}, "rm-1")
+        assert len(result["occurrences"]) == 5
+
+    def test_get_occurrence_found(self):
+        occ = self._make_occurrence()
+        with patch("series_storage.get_occurrence", return_value=occ):
+            result = _execute_query_tool("get_occurrence", {"occurrence_id": "occ-1"}, "rm-1")
+        assert result["occurrence_id"] == "occ-1"
+        assert result["host"] == "Alice"
+
+    def test_get_occurrence_not_found(self):
+        with patch("series_storage.get_occurrence", return_value=None):
+            result = _execute_query_tool("get_occurrence", {"occurrence_id": "missing"}, "rm-1")
+        assert "error" in result
+        assert "missing" in result["error"]
+
+    def test_unknown_tool(self):
+        result = _execute_query_tool("do_something", {}, "rm-1")
+        assert "error" in result

--- a/tests/test_telegram_chat_handler.py
+++ b/tests/test_telegram_chat_handler.py
@@ -3,23 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import uuid
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
+from unittest.mock import AsyncMock, patch
 
 from models import (
     ChatSession,
-    ChatTurn,
     Room,
     TelegramBotConfig,
-    TelegramUserLink,
 )
-
-
-def _utcnow():
-    return datetime.now(timezone.utc)
 
 
 def _make_bot_config(mode="read_write", **kwargs) -> TelegramBotConfig:
@@ -92,7 +82,6 @@ class TestHandleTelegramMessage:
             mock_storage.get_recent_turns.return_value = []
             mock_room_storage.get_room.return_value = _make_room()
             mock_series_storage.list_series_for_room.return_value = []
-            mock_series_storage.list_occurrences_for_room.return_value = []
             mock_stream.return_value = iter([
                 {"type": "text_chunk", "text": "Your next meeting is tomorrow."},
                 {"type": "done"},
@@ -148,7 +137,6 @@ class TestHandleTelegramMessage:
             mock_storage.get_recent_turns.return_value = []
             mock_room_storage.get_room.return_value = _make_room()
             mock_series_storage.list_series_for_room.return_value = []
-            mock_series_storage.list_occurrences_for_room.return_value = []
             mock_stream.return_value = iter([
                 {"type": "text_chunk", "text": "I'll create that series."},
                 {"type": "action_proposal", "action_id": "act-1",
@@ -186,7 +174,6 @@ class TestHandleTelegramMessage:
             mock_storage.get_recent_turns.return_value = []
             mock_room_storage.get_room.return_value = _make_room()
             mock_series_storage.list_series_for_room.return_value = []
-            mock_series_storage.list_occurrences_for_room.return_value = []
             mock_stream.return_value = iter([
                 {"type": "text_chunk", "text": "I'll create that."},
                 {"type": "action_proposal", "action_id": "act-1",
@@ -231,7 +218,6 @@ class TestHandleTelegramMessage:
             mock_storage.get_recent_turns.return_value = []
             mock_room_storage.get_room.return_value = _make_room()
             mock_series_storage.list_series_for_room.return_value = []
-            mock_series_storage.list_occurrences_for_room.return_value = []
 
             from telegram_chat_handler import handle_telegram_message
             _run(handle_telegram_message(
@@ -262,7 +248,6 @@ class TestHandleTelegramMessage:
             mock_storage.get_recent_turns.return_value = []
             mock_room_storage.get_room.return_value = _make_room(room_id="rm-correct")
             mock_series_storage.list_series_for_room.return_value = []
-            mock_series_storage.list_occurrences_for_room.return_value = []
             mock_stream.return_value = iter([
                 {"type": "text_chunk", "text": "ok"},
                 {"type": "done"},
@@ -280,6 +265,24 @@ class TestHandleTelegramMessage:
         mock_room_storage.get_room.assert_called_with("rm-correct")
         call_kwargs = mock_stream.call_args
         assert call_kwargs[1]["room_id"] == "rm-correct"
+
+    def test_room_context_does_not_prefetch_occurrences(self):
+        """_build_room_context should only fetch series, not occurrences."""
+        from telegram_chat_handler import _build_room_context
+
+        with (
+            patch("telegram_chat_handler.room_storage") as mock_room_storage,
+            patch("telegram_chat_handler.series_storage") as mock_series_storage,
+        ):
+            mock_room_storage.get_room.return_value = _make_room()
+            mock_series_storage.list_series_for_room.return_value = []
+
+            ctx = _build_room_context("rm-1")
+
+        assert ctx is not None
+        assert "series" in ctx
+        assert "upcoming_occurrences" not in ctx
+        mock_series_storage.list_occurrences_for_room.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds two Gemini function-calling tools (`list_occurrences`, `get_occurrence`) so the assistant can look up any occurrence by series and date range, instead of relying on a pre-fetched snapshot
- Removes the occurrence pre-fetch from `_build_room_context` — room context now contains only room metadata and series list
- Switches `_call_ai` from a single JSON-mode call to a multi-turn function-calling loop (up to 5 tool rounds before the final JSON response)

## Root cause (fixes #122)

`_build_room_context` fetched all occurrences sorted oldest-first, then took `[:20]`. Because the system never auto-marks past meetings as completed, old `status="scheduled"` occurrences filled the window and newly created occurrences were invisible to the agent.

## Test plan

- [x] `TestExecuteQueryTool` — 6 new unit tests covering `list_occurrences` (with date filter, limit) and `get_occurrence` (found, not found, unknown tool)
- [x] `test_room_context_does_not_prefetch_occurrences` — asserts `list_occurrences_for_room` is never called
- [x] All existing telegram handler and assistant action tests pass (43 passed, 6 skipped)
- [ ] Manual: harness 12.5 (create occurrence), 12.6 (update hosts on multiple occurrences), 10.6–10.7 (Telegram bot read-write + confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)