### PR TITLE
Set response_mime_type=application/json on Gemini configs

### DIFF
--- a/src/assistant.py
+++ b/src/assistant.py
@@ -266,6 +266,7 @@ def _call_ai(contents: list, room_id: str) -> dict:
     config = types.GenerateContentConfig(
         system_instruction=_SYSTEM_PROMPT,
         tools=[query_tools],
+        response_mime_type="application/json",
     )
 
     last_exc: Exception | None = None
@@ -320,6 +321,7 @@ def _call_ai(contents: list, room_id: str) -> dict:
                 )
                 text_only_config = types.GenerateContentConfig(
                     system_instruction=_SYSTEM_PROMPT,
+                    response_mime_type="application/json",
                 )
                 response = client.models.generate_content(
                     model=model,


### PR DESCRIPTION
## Summary

- Adds `response_mime_type="application/json"` to both `GenerateContentConfig` instances in `_call_ai` (the main tool-calling config and the loop-exhaustion fallback config).
- The model is now constrained at the token level to emit valid JSON, making prose preambles and markdown code fences structurally impossible.
- The `_extract_json_object` heuristic from the previous fix remains as a fallback for any edge cases, but should rarely be needed.

## Context

Production logs showed Gemini returning two malformed patterns despite the system prompt saying "no markdown fences":
1. Natural language prose before the JSON block
2. JSON wrapped in ` ```json ``` ` fences

Both caused `json.loads` to fail. `response_mime_type` is the model-level fix; the heuristic extraction was the defensive fix.

## Test plan

- [ ] All existing assistant tests pass (28 passed locally)
- [ ] Manual: send a message to the assistant via Telegram and confirm a response is returned without error
- [ ] Manual: ask the assistant to update multiple occurrences (harness 12.6) and confirm the batch action is proposed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)